### PR TITLE
feat: add allocation-driven market screen

### DIFF
--- a/src/economy/allocation.rs
+++ b/src/economy/allocation.rs
@@ -3,6 +3,12 @@ use std::collections::HashMap;
 
 use super::{goods::Good, reservation::ReservationId, workforce::WorkerSkill};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MarketOrderKind {
+    Buy,
+    Sell,
+}
+
 /// Per-nation component tracking all resource allocations via reservation IDs
 /// Each reservation represents ONE unit of output/worker/etc.
 #[derive(Component, Debug, Clone, Default)]
@@ -18,6 +24,12 @@ pub struct Allocations {
     /// Training allocations: skill level -> list of reservations
     /// Each ReservationId represents 1 worker training
     pub training: HashMap<WorkerSkill, Vec<ReservationId>>,
+
+    /// Market buy allocations: per-good reservations (each = 1 unit ordered)
+    pub market_buys: HashMap<Good, Vec<ReservationId>>,
+
+    /// Market sell allocations: per-good reservations (each = 1 unit offered)
+    pub market_sells: HashMap<Good, Vec<ReservationId>>,
 }
 
 impl Allocations {
@@ -37,6 +49,16 @@ impl Allocations {
     /// Get training count for a skill level
     pub fn training_count(&self, skill: WorkerSkill) -> usize {
         self.training.get(&skill).map(|v| v.len()).unwrap_or(0)
+    }
+
+    /// Get market buy allocation count for a good
+    pub fn market_buy_count(&self, good: Good) -> usize {
+        self.market_buys.get(&good).map(|v| v.len()).unwrap_or(0)
+    }
+
+    /// Get market sell allocation count for a good
+    pub fn market_sell_count(&self, good: Good) -> usize {
+        self.market_sells.get(&good).map(|v| v.len()).unwrap_or(0)
     }
 }
 
@@ -66,4 +88,13 @@ pub struct AdjustProduction {
     pub building: Entity,
     pub output_good: Good, // Which output to adjust (Paper, Lumber, etc.)
     pub target_output: u32,
+}
+
+/// Player adjusts market buy/sell allocation
+#[derive(Message, Debug, Clone, Copy)]
+pub struct AdjustMarketOrder {
+    pub nation: Entity,
+    pub good: Good,
+    pub kind: MarketOrderKind,
+    pub requested: u32,
 }

--- a/src/economy/market.rs
+++ b/src/economy/market.rs
@@ -1,0 +1,35 @@
+use crate::economy::Good;
+
+/// List of tradable resources currently exposed in the market UI.
+pub const MARKET_RESOURCES: &[Good] = &[
+    Good::Grain,
+    Good::Fruit,
+    Good::Livestock,
+    Good::Fish,
+    Good::Cotton,
+    Good::Wool,
+    Good::Timber,
+    Good::Coal,
+    Good::Iron,
+    Good::Gold,
+    Good::Gems,
+    Good::Oil,
+];
+
+/// Placeholder pricing table for the market screen.
+///
+/// Prices are intentionally simple for the initial UI and roughly mirror
+/// Imperialism's early-game values. They will be replaced by dynamic market
+/// clearing logic in a later milestone.
+pub fn market_price(good: Good) -> u32 {
+    match good {
+        Good::Grain | Good::Fruit => 60,
+        Good::Livestock | Good::Fish => 80,
+        Good::Cotton | Good::Wool => 90,
+        Good::Timber => 70,
+        Good::Coal | Good::Iron => 100,
+        Good::Gold | Good::Gems => 250,
+        Good::Oil => 110,
+        _ => 100,
+    }
+}

--- a/src/economy/mod.rs
+++ b/src/economy/mod.rs
@@ -5,18 +5,23 @@ pub mod goods;
 pub mod nation;
 pub mod production;
 pub mod reservation;
+pub mod market;
 pub mod stockpile;
 pub mod technology;
 pub mod transport;
 pub mod treasury;
 pub mod workforce;
 
-pub use allocation::{AdjustProduction, AdjustRecruitment, AdjustTraining, Allocations};
+pub use allocation::{
+    AdjustMarketOrder, AdjustProduction, AdjustRecruitment, AdjustTraining, Allocations,
+    MarketOrderKind,
+};
 pub use calendar::{Calendar, Season};
 pub use goods::Good;
 pub use nation::{Capital, Name, NationColor, NationId, PlayerNation};
 pub use production::{Building, BuildingKind};
 pub use reservation::{ReservationId, ReservationSystem, ResourcePool};
+pub use market::{market_price, MARKET_RESOURCES};
 pub use stockpile::Stockpile;
 pub use technology::{Technologies, Technology};
 pub use transport::{Depot, ImprovementKind, PlaceImprovement, Port, Rails, Roads};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,6 +303,7 @@ pub fn app() -> App {
             economy::allocation_systems::apply_recruitment_adjustments,
             economy::allocation_systems::apply_training_adjustments,
             economy::allocation_systems::apply_production_adjustments,
+            economy::allocation_systems::apply_market_order_adjustments,
             // Finalize allocations at turn end (before Processing)
             economy::allocation_systems::finalize_allocations
                 .run_if(resource_changed::<TurnSystem>)

--- a/src/ui/city/allocation_widgets.rs
+++ b/src/ui/city/allocation_widgets.rs
@@ -15,6 +15,8 @@ pub enum AllocationType {
     Recruitment,
     Training(WorkerSkill),
     Production(Entity, Good), // building entity + output good
+    MarketBuy(Good),
+    MarketSell(Good),
 }
 
 /// Generic stepper display (shows current allocated value)
@@ -35,6 +37,7 @@ pub struct AllocationStepperButton {
 pub struct AllocationBar {
     pub allocation_type: AllocationType,
     pub good: Good,
+    pub label: &'static str,
 }
 
 /// Generic summary text ("Will do X next turn")
@@ -204,6 +207,7 @@ macro_rules! spawn_allocation_bar {
                     AllocationBar {
                         allocation_type: $allocation_type,
                         good: $good,
+                        label: $good_name,
                     },
                 ));
 

--- a/src/ui/city/mod.rs
+++ b/src/ui/city/mod.rs
@@ -31,6 +31,7 @@ impl Plugin for CityUIPlugin {
             .add_message::<crate::economy::AdjustRecruitment>()
             .add_message::<crate::economy::AdjustTraining>()
             .add_message::<crate::economy::AdjustProduction>()
+            .add_message::<crate::economy::AdjustMarketOrder>()
             .add_systems(
                 OnEnter(crate::ui::mode::GameMode::City),
                 layout::ensure_city_screen_visible,

--- a/src/ui/market.rs
+++ b/src/ui/market.rs
@@ -1,17 +1,22 @@
 use bevy::prelude::*;
 
 use super::button_style::*;
-use crate::economy::{Good, PlayerNation, Treasury};
+use crate::economy::{
+    market_price, Allocations, Good, PlayerNation, Stockpile, Treasury, MARKET_RESOURCES,
+};
+use crate::ui::city::allocation_widgets::AllocationType;
 use crate::ui::mode::GameMode;
 
 #[derive(Component)]
 pub struct MarketScreen;
 
 #[derive(Component)]
-pub struct BuyClothButton;
+struct MarketInventoryText {
+    good: Good,
+}
 
 #[derive(Component)]
-pub struct SellClothButton;
+struct MarketTreasuryText;
 
 pub struct MarketUIPlugin;
 
@@ -21,43 +26,16 @@ impl Plugin for MarketUIPlugin {
             .add_systems(OnExit(GameMode::Market), hide_market_screen)
             .add_systems(
                 Update,
-                handle_market_buttons.run_if(in_state(GameMode::Market)),
+                (
+                    crate::ui::city::allocation_ui_unified::handle_all_stepper_buttons,
+                    crate::ui::city::allocation_ui_unified::update_all_stepper_displays,
+                    crate::ui::city::allocation_ui_unified::update_all_allocation_bars,
+                    crate::ui::city::allocation_ui_unified::update_all_allocation_summaries,
+                    update_market_treasury_text,
+                    update_market_inventory_texts,
+                )
+                    .run_if(in_state(GameMode::Market)),
             );
-    }
-}
-
-fn handle_market_buttons(
-    mut interactions: Query<
-        (
-            &Interaction,
-            Option<&BuyClothButton>,
-            Option<&SellClothButton>,
-        ),
-        Changed<Interaction>,
-    >,
-    player: Option<Res<PlayerNation>>,
-    mut treasuries: Query<&mut Treasury>,
-    mut stocks: Query<&mut crate::economy::Stockpile>,
-) {
-    if let Some(player) = player {
-        for (interaction, buy, sell) in interactions.iter_mut() {
-            if *interaction != Interaction::Pressed {
-                continue;
-            }
-            if let (Ok(mut t), Ok(mut s)) = (treasuries.get_mut(player.0), stocks.get_mut(player.0))
-            {
-                let price: i64 = 50; // fixed demo price
-                if buy.is_some() {
-                    if t.total() >= price {
-                        t.subtract(price);
-                        s.add(Good::Cloth, 1);
-                    }
-                } else if sell.is_some() && s.get(Good::Cloth) >= 1 {
-                    let _ = s.take_up_to(Good::Cloth, 1);
-                    t.add(price);
-                }
-            }
-        }
     }
 }
 
@@ -80,7 +58,7 @@ pub fn ensure_market_screen_visible(
                 bottom: Val::Px(0.0),
                 padding: UiRect::all(Val::Px(16.0)),
                 flex_direction: FlexDirection::Column,
-                row_gap: Val::Px(12.0),
+                row_gap: Val::Px(16.0),
                 ..default()
             },
             BackgroundColor(Color::srgba(0.06, 0.06, 0.06, 0.92)),
@@ -89,66 +67,148 @@ pub fn ensure_market_screen_visible(
         ))
         .with_children(|parent| {
             parent.spawn((
-                Text::new("Market Mode"),
+                Text::new("Board of Trade"),
                 TextFont {
-                    font_size: 24.0,
+                    font_size: 28.0,
                     ..default()
                 },
                 TextColor(Color::srgb(1.0, 0.95, 0.85)),
             ));
 
-            // Simple buy/sell controls
+            parent.spawn((
+                Text::new("Treasury available: $0"),
+                TextFont {
+                    font_size: 18.0,
+                    ..default()
+                },
+                TextColor(Color::srgb(0.8, 0.95, 1.0)),
+                MarketTreasuryText,
+            ));
+
             parent
                 .spawn((
                     Node {
-                        flex_direction: FlexDirection::Row,
-                        column_gap: Val::Px(10.0),
+                        flex_direction: FlexDirection::Column,
+                        row_gap: Val::Px(12.0),
                         ..default()
                     },
                     BackgroundColor(Color::srgba(0.12, 0.12, 0.12, 0.6)),
                 ))
-                .with_children(|row| {
-                    row.spawn((
-                        Button,
-                        Node {
-                            padding: UiRect::all(Val::Px(6.0)),
-                            ..default()
-                        },
-                        BackgroundColor(NORMAL_BUTTON),
-                        BuyClothButton,
-                    ))
-                    .with_children(|b| {
-                        b.spawn((
-                            Text::new("Buy 1 Cloth ($50)"),
-                            TextFont {
-                                font_size: 16.0,
-                                ..default()
-                            },
-                            TextColor(Color::srgb(0.9, 0.9, 1.0)),
-                        ));
-                    });
-                    row.spawn((
-                        Button,
-                        Node {
-                            padding: UiRect::all(Val::Px(6.0)),
-                            ..default()
-                        },
-                        BackgroundColor(NORMAL_BUTTON),
-                        SellClothButton,
-                    ))
-                    .with_children(|b| {
-                        b.spawn((
-                            Text::new("Sell 1 Cloth ($50)"),
-                            TextFont {
-                                font_size: 16.0,
-                                ..default()
-                            },
-                            TextColor(Color::srgb(0.9, 0.9, 1.0)),
-                        ));
-                    });
+                .with_children(|list| {
+                    for &good in MARKET_RESOURCES {
+                        let price = market_price(good);
+                        let good_name = good.to_string();
+                        list
+                            .spawn((
+                                Node {
+                                    width: Val::Percent(100.0),
+                                    flex_direction: FlexDirection::Row,
+                                    column_gap: Val::Px(18.0),
+                                    padding: UiRect::all(Val::Px(12.0)),
+                                    align_items: AlignItems::FlexStart,
+                                    ..default()
+                                },
+                                BackgroundColor(Color::srgba(0.1, 0.1, 0.1, 0.85)),
+                            ))
+                            .with_children(|row| {
+                                // Info column
+                                row
+                                    .spawn((
+                                        Node {
+                                            flex_direction: FlexDirection::Column,
+                                            row_gap: Val::Px(4.0),
+                                            min_width: Val::Px(160.0),
+                                            ..default()
+                                        },
+                                    ))
+                                    .with_children(|info| {
+                                        info.spawn((
+                                            Text::new(good_name.clone()),
+                                            TextFont {
+                                                font_size: 18.0,
+                                                ..default()
+                                            },
+                                            TextColor(Color::srgb(0.95, 0.95, 0.9)),
+                                        ));
+                                        info.spawn((
+                                            Text::new(format!("Price: ${}", price)),
+                                            TextFont {
+                                                font_size: 14.0,
+                                                ..default()
+                                            },
+                                            TextColor(Color::srgb(0.75, 0.85, 1.0)),
+                                        ));
+                                        info.spawn((
+                                            Text::new("Stockpile: 0 free / 0 total (market 0)"),
+                                            TextFont {
+                                                font_size: 14.0,
+                                                ..default()
+                                            },
+                                            TextColor(Color::srgb(0.85, 0.85, 0.85)),
+                                            MarketInventoryText { good },
+                                        ));
+                                    });
+
+                                // Buy column
+                                row
+                                    .spawn((
+                                        Node {
+                                            flex_direction: FlexDirection::Column,
+                                            row_gap: Val::Px(6.0),
+                                            min_width: Val::Px(220.0),
+                                            ..default()
+                                        },
+                                    ))
+                                    .with_children(|buy| {
+                                        crate::spawn_allocation_stepper!(
+                                            buy,
+                                            "Buy Orders",
+                                            AllocationType::MarketBuy(good)
+                                        );
+                                        crate::spawn_allocation_bar!(
+                                            buy,
+                                            Good::Gold,
+                                            "Treasury",
+                                            AllocationType::MarketBuy(good)
+                                        );
+                                        crate::spawn_allocation_summary!(
+                                            buy,
+                                            AllocationType::MarketBuy(good)
+                                        );
+                                    });
+
+                                // Sell column
+                                row
+                                    .spawn((
+                                        Node {
+                                            flex_direction: FlexDirection::Column,
+                                            row_gap: Val::Px(6.0),
+                                            min_width: Val::Px(220.0),
+                                            ..default()
+                                        },
+                                    ))
+                                    .with_children(|sell| {
+                                        crate::spawn_allocation_stepper!(
+                                            sell,
+                                            "Sell Offers",
+                                            AllocationType::MarketSell(good)
+                                        );
+                                        crate::spawn_allocation_bar!(
+                                            sell,
+                                            good,
+                                            "Inventory",
+                                            AllocationType::MarketSell(good)
+                                        );
+                                        crate::spawn_allocation_summary!(
+                                            sell,
+                                            AllocationType::MarketSell(good)
+                                        );
+                                    });
+                            });
+                    }
                 });
 
-            // Back to Map
+            // Back to Map button
             parent
                 .spawn((
                     Button,
@@ -173,6 +233,74 @@ pub fn ensure_market_screen_visible(
                     ));
                 });
         });
+}
+
+fn update_market_treasury_text(
+    player: Option<Res<PlayerNation>>,
+    treasuries: Query<&Treasury>,
+    allocations_changed: Query<Entity, Changed<Allocations>>,
+    mut texts: Query<&mut Text, With<MarketTreasuryText>>,
+    treasury_changed: Query<Entity, Changed<Treasury>>,
+    new_texts: Query<Entity, Added<MarketTreasuryText>>,
+) {
+    let Some(player) = player else { return; };
+
+    if treasury_changed.is_empty() && allocations_changed.is_empty() && new_texts.is_empty() {
+        return;
+    }
+
+    let Ok(treasury) = treasuries.get(player.0) else {
+        return;
+    };
+
+    let available = treasury.available();
+    let reserved = treasury.reserved();
+
+    for mut text in texts.iter_mut() {
+        text.0 = format!(
+            "Treasury available: ${} (reserved ${})",
+            available,
+            reserved
+        );
+    }
+}
+
+fn update_market_inventory_texts(
+    player: Option<Res<PlayerNation>>,
+    stockpiles: Query<&Stockpile>,
+    allocations: Query<&Allocations>,
+    mut texts: Query<(&mut Text, &MarketInventoryText)>,
+    stockpile_changed: Query<Entity, Changed<Stockpile>>,
+    allocations_changed: Query<Entity, Changed<Allocations>>,
+    new_texts: Query<Entity, Added<MarketInventoryText>>,
+) {
+    let Some(player) = player else { return; };
+
+    if stockpile_changed.is_empty() && allocations_changed.is_empty() && new_texts.is_empty() {
+        return;
+    }
+
+    let Ok(stockpile) = stockpiles.get(player.0) else {
+        return;
+    };
+
+    let Ok(allocations) = allocations.get(player.0) else {
+        return;
+    };
+
+    for (mut text, marker) in texts.iter_mut() {
+        let total = stockpile.get(marker.good);
+        let reserved = stockpile.get_reserved(marker.good);
+        let available = stockpile.get_available(marker.good);
+        let market_reserved = allocations.market_sell_count(marker.good) as u32;
+        text.0 = format!(
+            "Stockpile: {} free / {} total (reserved {}, market {})",
+            available,
+            total,
+            reserved,
+            market_reserved
+        );
+    }
 }
 
 pub fn hide_market_screen(mut roots: Query<&mut Visibility, With<MarketScreen>>) {


### PR DESCRIPTION
## Summary
- replace the market overlay with allocation widgets so each resource can declare buy and sell orders
- extend the allocation systems with market-specific reservations and pricing helpers
- surface treasury and stockpile details in the market UI while sharing the generic allocation update systems

## Testing
- cargo test *(fails: system library `wayland-client` is missing for pkg-config)*

------
https://chatgpt.com/codex/tasks/task_b_68f18726cae4832fae6c2da8a63b8cf3