### PR TITLE
Use NationId instances for nation handles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3726,6 +3726,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "moonshine-kind"
+version = "0.4.1"
+source = "git+https://github.com/Zeenobit/moonshine_kind?rev=5e3b12d58b5292bb043b87b8f4f6342256ef9982#5e3b12d58b5292bb043b87b8f4f6342256ef9982"
+dependencies = [
+ "bevy_ecs",
+ "bevy_reflect 0.17.2",
+ "bevy_utils 0.17.2",
+ "disqualified",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4906,6 +4917,7 @@ dependencies = [
  "bevy_ecs_tilemap",
  "hexx",
  "image",
+ "moonshine-kind",
  "noise",
  "rand 0.9.2",
  "thiserror 2.0.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,5 @@ noise = "0.9"
 bevy-inspector-egui = "0.34.0"
 image = "0.25"
 thiserror = "2.0"
+moonshine-kind = { git = "https://github.com/Zeenobit/moonshine_kind", rev = "5e3b12d58b5292bb043b87b8f4f6342256ef9982" }
 

--- a/src/economy/allocation.rs
+++ b/src/economy/allocation.rs
@@ -2,6 +2,7 @@ use bevy::prelude::*;
 use std::collections::{HashMap, HashSet};
 
 use super::{goods::Good, reservation::ReservationId, workforce::WorkerSkill};
+use crate::economy::NationInstance;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum MarketInterest {
@@ -71,14 +72,14 @@ impl Allocations {
 /// Player adjusts recruitment allocation (Capitol building)
 #[derive(Message, Debug, Clone, Copy)]
 pub struct AdjustRecruitment {
-    pub nation: Entity,
+    pub nation: NationInstance,
     pub requested: u32,
 }
 
 /// Player adjusts training allocation (Trade School)
 #[derive(Message, Debug, Clone, Copy)]
 pub struct AdjustTraining {
-    pub nation: Entity,
+    pub nation: NationInstance,
     pub from_skill: WorkerSkill,
     pub requested: u32,
 }
@@ -86,7 +87,7 @@ pub struct AdjustTraining {
 /// Player adjusts production allocation (mills/factories)
 #[derive(Message, Debug, Clone, Copy)]
 pub struct AdjustProduction {
-    pub nation: Entity,
+    pub nation: NationInstance,
     pub building: Entity,
     pub output_good: Good, // Which output to adjust (Paper, Lumber, etc.)
     pub target_output: u32,
@@ -97,7 +98,7 @@ pub struct AdjustProduction {
 /// For Sell: requested is the actual quantity to allocate
 #[derive(Message, Debug, Clone, Copy)]
 pub struct AdjustMarketOrder {
-    pub nation: Entity,
+    pub nation: NationInstance,
     pub good: Good,
     pub kind: MarketInterest,
     pub requested: u32,

--- a/src/economy/allocation_systems/mod.rs
+++ b/src/economy/allocation_systems/mod.rs
@@ -32,7 +32,7 @@ pub fn apply_production_adjustments(
 ) {
     for msg in messages.read() {
         let Ok((mut allocations, mut reservations, mut stockpile, mut workforce)) =
-            nations.get_mut(msg.nation)
+            nations.get_mut(msg.nation.entity())
         else {
             warn!("Cannot adjust production: nation not found");
             continue;
@@ -255,7 +255,8 @@ pub fn apply_recruitment_adjustments(
     recruitment_capacity: Query<&RecruitmentCapacity>,
 ) {
     for msg in messages.read() {
-        let Ok((mut allocations, mut reservations, mut stockpile)) = nations.get_mut(msg.nation)
+        let Ok((mut allocations, mut reservations, mut stockpile)) =
+            nations.get_mut(msg.nation.entity())
         else {
             warn!("Cannot adjust recruitment: nation not found");
             continue;
@@ -264,11 +265,11 @@ pub fn apply_recruitment_adjustments(
         // Calculate capacity cap
         let province_count = provinces
             .iter()
-            .filter(|p| p.owner == Some(msg.nation))
+            .filter(|p| p.owner == Some(msg.nation.entity()))
             .count() as u32;
 
         let capacity_upgraded = recruitment_capacity
-            .get(msg.nation)
+            .get(msg.nation.entity())
             .map(|c| c.upgraded)
             .unwrap_or(false);
 
@@ -356,7 +357,7 @@ pub fn apply_training_adjustments(
 ) {
     for msg in messages.read() {
         let Ok((mut allocations, mut reservations, mut stockpile, workforce, mut treasury)) =
-            nations.get_mut(msg.nation)
+            nations.get_mut(msg.nation.entity())
         else {
             warn!("Cannot adjust training: nation not found");
             continue;
@@ -446,7 +447,7 @@ pub fn apply_market_order_adjustments(
 ) {
     for msg in messages.read() {
         let Ok((mut allocations, mut reservations, mut stockpile, mut workforce, mut treasury)) =
-            nations.get_mut(msg.nation)
+            nations.get_mut(msg.nation.entity())
         else {
             warn!("Cannot adjust market orders: nation not found");
             continue;

--- a/src/economy/mod.rs
+++ b/src/economy/mod.rs
@@ -19,7 +19,7 @@ pub use allocation::{
 pub use calendar::{Calendar, Season};
 pub use goods::Good;
 pub use market::{MARKET_RESOURCES, market_price};
-pub use nation::{Capital, Name, NationColor, NationId, PlayerNation};
+pub use nation::{Capital, Name, NationColor, NationId, NationInstance, PlayerNation};
 pub use production::{Building, BuildingKind};
 pub use reservation::{ReservationId, ReservationSystem, ResourcePool};
 pub use stockpile::Stockpile;

--- a/src/economy/nation.rs
+++ b/src/economy/nation.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use bevy_ecs_tilemap::prelude::TilePos;
+use moonshine_kind::Instance;
 
 /// Unique identifier for a nation (stable across saves)
 #[derive(Component, Clone, Copy, Debug, Eq, PartialEq, Hash)]
@@ -9,13 +10,44 @@ pub struct NationId(pub u16);
 #[derive(Component, Clone, Debug)]
 pub struct Name(pub String);
 
+/// Type-safe handle to a nation entity.
+pub type NationInstance = Instance<NationId>;
+
 /// Capital tile position for a nation (used for rail network connectivity)
 #[derive(Component, Clone, Copy, Debug)]
 pub struct Capital(pub TilePos);
 
 /// Resource pointing to the player's active nation entity
 #[derive(Resource, Clone, Copy, Debug)]
-pub struct PlayerNation(pub Entity);
+pub struct PlayerNation(pub NationInstance);
+
+impl PlayerNation {
+    /// Creates a new resource from the given nation instance.
+    pub fn new(instance: NationInstance) -> Self {
+        Self(instance)
+    }
+
+    /// Attempts to create a player nation reference from the given entity.
+    ///
+    /// Returns [`None`] if the entity does not contain a [`NationId`] component.
+    pub fn from_entity(world: &World, entity: Entity) -> Option<Self> {
+        world
+            .get_entity(entity)
+            .ok()
+            .and_then(Instance::<NationId>::from_entity)
+            .map(Self)
+    }
+
+    /// Returns the instance of the player's nation.
+    pub fn instance(&self) -> NationInstance {
+        self.0
+    }
+
+    /// Returns the underlying entity for the player's nation.
+    pub fn entity(&self) -> Entity {
+        self.0.entity()
+    }
+}
 
 /// Nation display color (for borders and UI)
 #[derive(Component, Clone, Copy, Debug)]

--- a/src/economy/transport/input.rs
+++ b/src/economy/transport/input.rs
@@ -97,7 +97,7 @@ fn handle_road_placement(
     } else {
         let cost: i64 = 10;
         if let Some(player) = &player
-            && let Ok(mut treasury) = treasuries.get_mut(player.0)
+            && let Ok(mut treasury) = treasuries.get_mut(player.entity())
         {
             if treasury.total() >= cost {
                 treasury.subtract(cost);
@@ -151,7 +151,8 @@ fn handle_rail_construction(
     // Check terrain buildability for both endpoints
     if let Some(player) = &player {
         // Get player nation's technologies
-        let player_techs = nations.get(player.0).ok();
+        let player_entity = player.entity();
+        let player_techs = nations.get(player_entity).ok();
 
         // Check both tiles for terrain restrictions
         let mut can_build = true;
@@ -224,37 +225,39 @@ fn handle_rail_construction(
 
     // Start rail construction (takes 3 turns)
     let cost: i64 = 50;
-    if let Some(player) = &player
-        && let Ok(mut treasury) = treasuries.get_mut(player.0)
-    {
-        if treasury.total() >= cost {
-            treasury.subtract(cost);
+    if let Some(player) = &player {
+        let player_entity = player.entity();
 
-            // Use the engineer from the message, or a dummy entity if not provided
-            let engineer = e.engineer.unwrap_or(player.0);
+        if let Ok(mut treasury) = treasuries.get_mut(player_entity) {
+            if treasury.total() >= cost {
+                treasury.subtract(cost);
 
-            commands.spawn(RailConstruction {
-                from: edge.0,
-                to: edge.1,
-                turns_remaining: 3,
-                owner: player.0,
-                engineer,
-            });
+                // Use the engineer from the message, or a dummy entity if not provided
+                let engineer = e.engineer.unwrap_or(player_entity);
 
-            log_events.write(TerminalLogEvent {
-                message: format!(
-                    "Started rail construction from ({}, {}) to ({}, {}) for ${} (3 turns)",
-                    edge.0.x, edge.0.y, edge.1.x, edge.1.y, cost
-                ),
-            });
-        } else {
-            log_events.write(TerminalLogEvent {
-                message: format!(
-                    "Not enough money to build rail (need ${}, have ${})",
-                    cost,
-                    treasury.total()
-                ),
-            });
+                commands.spawn(RailConstruction {
+                    from: edge.0,
+                    to: edge.1,
+                    turns_remaining: 3,
+                    owner: player_entity,
+                    engineer,
+                });
+
+                log_events.write(TerminalLogEvent {
+                    message: format!(
+                        "Started rail construction from ({}, {}) to ({}, {}) for ${} (3 turns)",
+                        edge.0.x, edge.0.y, edge.1.x, edge.1.y, cost
+                    ),
+                });
+            } else {
+                log_events.write(TerminalLogEvent {
+                    message: format!(
+                        "Not enough money to build rail (need ${}, have ${})",
+                        cost,
+                        treasury.total()
+                    ),
+                });
+            }
         }
     }
 }
@@ -268,27 +271,29 @@ fn handle_depot_placement(
 ) {
     // Depot is placed on a single tile (use position 'a', ignore 'b')
     let cost: i64 = 100;
-    if let Some(player) = &player
-        && let Ok(mut treasury) = treasuries.get_mut(player.0)
-    {
-        if treasury.total() >= cost {
-            treasury.subtract(cost);
-            commands.spawn(Depot {
-                position: a,
-                owner: player.0,  // Set owner to player nation
-                connected: false, // Will be computed by connectivity system
-            });
-            log_events.write(TerminalLogEvent {
-                message: format!("Built depot at ({}, {}) for ${}", a.x, a.y, cost),
-            });
-        } else {
-            log_events.write(TerminalLogEvent {
-                message: format!(
-                    "Not enough money to build depot (need ${}, have ${})",
-                    cost,
-                    treasury.total()
-                ),
-            });
+    if let Some(player) = &player {
+        let player_entity = player.entity();
+
+        if let Ok(mut treasury) = treasuries.get_mut(player_entity) {
+            if treasury.total() >= cost {
+                treasury.subtract(cost);
+                commands.spawn(Depot {
+                    position: a,
+                    owner: player_entity, // Set owner to player nation
+                    connected: false,     // Will be computed by connectivity system
+                });
+                log_events.write(TerminalLogEvent {
+                    message: format!("Built depot at ({}, {}) for ${}", a.x, a.y, cost),
+                });
+            } else {
+                log_events.write(TerminalLogEvent {
+                    message: format!(
+                        "Not enough money to build depot (need ${}, have ${})",
+                        cost,
+                        treasury.total()
+                    ),
+                });
+            }
         }
     }
 }
@@ -336,28 +341,30 @@ fn handle_port_placement(
 
     // Port is placed on a single tile
     let cost: i64 = 150;
-    if let Some(player) = &player
-        && let Ok(mut treasury) = treasuries.get_mut(player.0)
-    {
-        if treasury.total() >= cost {
-            treasury.subtract(cost);
-            commands.spawn(Port {
-                position: a,
-                owner: player.0, // Set owner to player nation
-                connected: false,
-                is_river: false, // TODO: detect from terrain
-            });
-            log_events.write(TerminalLogEvent {
-                message: format!("Built port at ({}, {}) for ${}", a.x, a.y, cost),
-            });
-        } else {
-            log_events.write(TerminalLogEvent {
-                message: format!(
-                    "Not enough money to build port (need ${}, have ${})",
-                    cost,
-                    treasury.total()
-                ),
-            });
+    if let Some(player) = &player {
+        let player_entity = player.entity();
+
+        if let Ok(mut treasury) = treasuries.get_mut(player_entity) {
+            if treasury.total() >= cost {
+                treasury.subtract(cost);
+                commands.spawn(Port {
+                    position: a,
+                    owner: player_entity, // Set owner to player nation
+                    connected: false,
+                    is_river: false, // TODO: detect from terrain
+                });
+                log_events.write(TerminalLogEvent {
+                    message: format!("Built port at ({}, {}) for ${}", a.x, a.y, cost),
+                });
+            } else {
+                log_events.write(TerminalLogEvent {
+                    message: format!(
+                        "Not enough money to build port (need ${}, have ${})",
+                        cost,
+                        treasury.total()
+                    ),
+                });
+            }
         }
     }
 }

--- a/src/economy/workforce/recruitment.rs
+++ b/src/economy/workforce/recruitment.rs
@@ -4,6 +4,7 @@ use super::super::goods::Good;
 use super::super::stockpile::Stockpile;
 use super::systems::calculate_recruitment_cap;
 use super::types::{RecruitmentCapacity, Workforce};
+use crate::economy::NationInstance;
 use crate::province::Province;
 use crate::turn_system::{TurnPhase, TurnSystem};
 use crate::ui::logging::TerminalLogEvent;
@@ -11,7 +12,7 @@ use crate::ui::logging::TerminalLogEvent;
 /// Message to queue recruitment of untrained workers at the Capitol
 #[derive(Message, Debug, Clone, Copy)]
 pub struct RecruitWorkers {
-    pub nation: Entity,
+    pub nation: NationInstance,
     pub count: u32,
 }
 
@@ -32,15 +33,15 @@ pub fn handle_recruitment(
     mut log_writer: MessageWriter<TerminalLogEvent>,
 ) {
     for event in events.read() {
-        if let Ok((mut queue, mut stockpile)) = nations.get_mut(event.nation) {
+        if let Ok((mut queue, mut stockpile)) = nations.get_mut(event.nation.entity()) {
             // Calculate recruitment cap (count provinces owned by this nation entity)
             let province_count = provinces
                 .iter()
-                .filter(|p| p.owner == Some(event.nation))
+                .filter(|p| p.owner == Some(event.nation.entity()))
                 .count() as u32;
 
             let capacity = recruitment_capacity
-                .get(event.nation)
+                .get(event.nation.entity())
                 .map(|c| c.upgraded)
                 .unwrap_or(false);
 

--- a/src/economy/workforce/training.rs
+++ b/src/economy/workforce/training.rs
@@ -3,6 +3,7 @@ use bevy::prelude::*;
 use super::super::goods::Good;
 use super::super::stockpile::Stockpile;
 use super::types::{WorkerSkill, Workforce};
+use crate::economy::NationInstance;
 use crate::economy::treasury::Treasury;
 use crate::turn_system::{TurnPhase, TurnSystem};
 use crate::ui::logging::TerminalLogEvent;
@@ -10,7 +11,7 @@ use crate::ui::logging::TerminalLogEvent;
 /// Message to queue training of a worker at the Trade School
 #[derive(Message, Debug, Clone, Copy)]
 pub struct TrainWorker {
-    pub nation: Entity,
+    pub nation: NationInstance,
     pub from_skill: WorkerSkill,
 }
 
@@ -51,7 +52,9 @@ pub fn handle_training(
     const TRAINING_COST_CASH: i64 = 100;
 
     for event in events.read() {
-        if let Ok((workforce, mut stockpile, treasury, mut queue)) = nations.get_mut(event.nation) {
+        if let Ok((workforce, mut stockpile, treasury, mut queue)) =
+            nations.get_mut(event.nation.entity())
+        {
             // Calculate total training orders of this type (including queued)
             let already_queued = queue
                 .orders

--- a/src/province_setup.rs
+++ b/src/province_setup.rs
@@ -168,8 +168,14 @@ pub fn assign_provinces_to_countries(
     }
 
     // Set player nation reference
-    if !country_entities.is_empty() {
-        commands.insert_resource(PlayerNation(country_entities[0]));
+    if let Some(&player_entity) = country_entities.first() {
+        commands.queue(move |world: &mut World| {
+            if let Some(player_nation) = PlayerNation::from_entity(world, player_entity) {
+                world.insert_resource(player_nation);
+            } else {
+                warn!("Failed to initialize player nation from entity {player_entity:?}");
+            }
+        });
     }
 
     // Build adjacency map for provinces

--- a/src/ui/city/allocation_ui_unified.rs
+++ b/src/ui/city/allocation_ui_unified.rs
@@ -27,7 +27,10 @@ pub fn handle_all_stepper_buttons(
         return;
     };
 
-    let Ok(alloc) = allocations.get(player.0) else {
+    let player_entity = player.entity();
+    let player_instance = player.instance();
+
+    let Ok(alloc) = allocations.get(player_entity) else {
         return;
     };
 
@@ -38,7 +41,7 @@ pub fn handle_all_stepper_buttons(
                     let current = alloc.recruitment_count() as u32;
                     let new_requested = (current as i32 + button.delta).max(0) as u32;
                     recruit_writer.write(AdjustRecruitment {
-                        nation: player.0,
+                        nation: player_instance,
                         requested: new_requested,
                     });
                     info!(
@@ -51,7 +54,7 @@ pub fn handle_all_stepper_buttons(
                     let current = alloc.training_count(from_skill) as u32;
                     let new_requested = (current as i32 + button.delta).max(0) as u32;
                     train_writer.write(AdjustTraining {
-                        nation: player.0,
+                        nation: player_instance,
                         from_skill,
                         requested: new_requested,
                     });
@@ -65,7 +68,7 @@ pub fn handle_all_stepper_buttons(
                     let current = alloc.production_count(building_entity, output_good) as u32;
                     let new_target = (current as i32 + button.delta).max(0) as u32;
                     prod_writer.write(AdjustProduction {
-                        nation: player.0,
+                        nation: player_instance,
                         building: building_entity,
                         output_good,
                         target_output: new_target,
@@ -81,7 +84,7 @@ pub fn handle_all_stepper_buttons(
                     let current = if alloc.has_buy_interest(good) { 1 } else { 0 };
                     let new_requested = if current == 0 { 1 } else { 0 };
                     market_writer.write(AdjustMarketOrder {
-                        nation: player.0,
+                        nation: player_instance,
                         good,
                         kind: MarketInterest::Buy,
                         requested: new_requested,
@@ -98,7 +101,7 @@ pub fn handle_all_stepper_buttons(
                     let current = alloc.market_sell_count(good) as u32;
                     let new_requested = (current as i32 + button.delta).max(0) as u32;
                     market_writer.write(AdjustMarketOrder {
-                        nation: player.0,
+                        nation: player_instance,
                         good,
                         kind: MarketInterest::Sell,
                         requested: new_requested,
@@ -134,7 +137,7 @@ pub fn update_all_stepper_displays(
         return;
     }
 
-    if let Ok(alloc) = allocations.get(player.0) {
+    if let Ok(alloc) = allocations.get(player.entity()) {
         for (mut text, display) in displays.iter_mut() {
             let allocated = match display.allocation_type {
                 AllocationType::Recruitment => alloc.recruitment_count(),
@@ -189,19 +192,21 @@ pub fn update_all_allocation_bars(
         return;
     }
 
-    let Ok(alloc) = allocations.get(player.0) else {
+    let player_entity = player.entity();
+
+    let Ok(alloc) = allocations.get(player_entity) else {
         return;
     };
 
-    let Ok(stockpile) = stockpiles.get(player.0) else {
+    let Ok(stockpile) = stockpiles.get(player_entity) else {
         return;
     };
 
-    let Ok(buildings_collection) = buildings_query.get(player.0) else {
+    let Ok(buildings_collection) = buildings_query.get(player_entity) else {
         return;
     };
 
-    let Ok(_treasury) = treasuries.get(player.0) else {
+    let Ok(_treasury) = treasuries.get(player_entity) else {
         return;
     };
 
@@ -322,7 +327,7 @@ pub fn update_all_allocation_summaries(
         return;
     }
 
-    if let Ok(alloc) = allocations.get(player.0) {
+    if let Ok(alloc) = allocations.get(player.entity()) {
         for (mut text, summary) in summaries.iter_mut() {
             text.0 = match summary.allocation_type {
                 AllocationType::Recruitment => {

--- a/src/ui/city/buildings/grid.rs
+++ b/src/ui/city/buildings/grid.rs
@@ -115,7 +115,8 @@ pub fn update_building_buttons(
     };
 
     // Get player's buildings collection
-    let player_buildings = player_buildings_query.get(player.0).ok();
+    let player_entity = player.entity();
+    let player_buildings = player_buildings_query.get(player_entity).ok();
 
     // Update button states
     for (mut button, mut bg_color, mut border_color) in button_query.iter_mut() {
@@ -133,7 +134,7 @@ pub fn update_building_buttons(
 
         if is_built {
             // Building is built - highlight button
-            button.building_entity = Some(player.0);
+            button.building_entity = Some(player_entity);
             *bg_color = BackgroundColor(Color::srgba(0.2, 0.3, 0.4, 1.0)); // Brighter
             *border_color = BorderColor::all(Color::srgba(0.4, 0.6, 0.8, 1.0)); // Blue border
         } else {

--- a/src/ui/city/dialogs/production.rs
+++ b/src/ui/city/dialogs/production.rs
@@ -22,19 +22,19 @@ pub fn populate_production_dialog(
         return;
     };
 
-    let Ok(stockpile) = stockpiles.get(player.0) else {
+    let Ok(stockpile) = stockpiles.get(player.entity()) else {
         return;
     };
 
-    let Ok(workforce) = workforces.get(player.0) else {
+    let Ok(workforce) = workforces.get(player.entity()) else {
         return;
     };
 
-    let Ok(buildings_collection) = buildings_collections.get(player.0) else {
+    let Ok(buildings_collection) = buildings_collections.get(player.entity()) else {
         return;
     };
 
-    let Ok(settings) = settings_query.get(player.0) else {
+    let Ok(settings) = settings_query.get(player.entity()) else {
         return;
     };
 
@@ -374,11 +374,11 @@ pub fn update_production_labor_display(
         return;
     };
 
-    let Ok(workforce) = workforce_query.get(player.0) else {
+    let Ok(workforce) = workforce_query.get(player.entity()) else {
         return;
     };
 
-    let Ok(allocations) = allocations_query.get(player.0) else {
+    let Ok(allocations) = allocations_query.get(player.entity()) else {
         return;
     };
 

--- a/src/ui/city/dialogs/special.rs
+++ b/src/ui/city/dialogs/special.rs
@@ -29,11 +29,13 @@ pub fn populate_special_dialog(
         return;
     };
 
-    let Ok(stockpile) = stockpiles.get(player.0) else {
+    let player_entity = player.entity();
+
+    let Ok(stockpile) = stockpiles.get(player_entity) else {
         return;
     };
 
-    let Ok(workforce) = workforces.get(player.0) else {
+    let Ok(workforce) = workforces.get(player_entity) else {
         return;
     };
 
@@ -45,7 +47,7 @@ pub fn populate_special_dialog(
                 // Calculate province count
                 let province_count = provinces
                     .iter()
-                    .filter(|p| p.owner == Some(player.0))
+                    .filter(|p| p.owner == Some(player_entity))
                     .count() as u32;
 
                 spawn_capitol_content(
@@ -53,8 +55,8 @@ pub fn populate_special_dialog(
                     content_entity,
                     stockpile,
                     province_count,
-                    recruitment_caps.get(player.0).ok(),
-                    recruitment_queues.get(player.0).ok(),
+                    recruitment_caps.get(player_entity).ok(),
+                    recruitment_queues.get(player_entity).ok(),
                 );
             }
             BuildingKind::TradeSchool => {
@@ -470,7 +472,9 @@ pub fn update_capitol_requirement_displays(
         return;
     };
 
-    let Ok(stockpile) = stockpile_query.get(player.0) else {
+    let player_entity = player.entity();
+
+    let Ok(stockpile) = stockpile_query.get(player_entity) else {
         return;
     };
 
@@ -504,22 +508,24 @@ pub fn update_capitol_capacity_display(
         return;
     };
 
-    let Ok(_queue) = recruitment_queue_query.get(player.0) else {
+    let player_entity = player.entity();
+
+    let Ok(_queue) = recruitment_queue_query.get(player_entity) else {
         return;
     };
 
     let province_count = provinces
         .iter()
-        .filter(|p| p.owner == Some(player.0))
+        .filter(|p| p.owner == Some(player_entity))
         .count() as u32;
 
     let upgraded = recruitment_cap_query
-        .get(player.0)
+        .get(player_entity)
         .map(|c| c.upgraded)
         .unwrap_or(false);
     let cap = calculate_recruitment_cap(province_count, upgraded);
     let queued = recruitment_queue_query
-        .get(player.0)
+        .get(player_entity)
         .map(|q| q.queued)
         .unwrap_or(0);
     let remaining = cap.saturating_sub(queued);
@@ -546,7 +552,9 @@ pub fn update_trade_school_workforce_display(
         return;
     };
 
-    let Ok(workforce) = workforce_query.get(player.0) else {
+    let player_entity = player.entity();
+
+    let Ok(workforce) = workforce_query.get(player_entity) else {
         return;
     };
 
@@ -583,7 +591,9 @@ pub fn update_trade_school_paper_display(
         return;
     };
 
-    let Ok(stockpile) = stockpile_query.get(player.0) else {
+    let player_entity = player.entity();
+
+    let Ok(stockpile) = stockpile_query.get(player_entity) else {
         return;
     };
 

--- a/src/ui/city/hud/food.rs
+++ b/src/ui/city/hud/food.rs
@@ -84,7 +84,7 @@ pub fn update_food_demand_display(
         return;
     };
 
-    let Ok(workforce) = workforce_query.get(player.0) else {
+    let Ok(workforce) = workforce_query.get(player.entity()) else {
         return;
     };
 

--- a/src/ui/city/hud/labor.rs
+++ b/src/ui/city/hud/labor.rs
@@ -85,7 +85,7 @@ pub fn update_labor_display(
         return;
     };
 
-    let Ok(workforce) = workforce_query.get(player.0) else {
+    let Ok(workforce) = workforce_query.get(player.entity()) else {
         return;
     };
 
@@ -106,7 +106,7 @@ pub fn update_workforce_display(
         return;
     };
 
-    let Ok(workforce) = workforce_query.get(player.0) else {
+    let Ok(workforce) = workforce_query.get(player.entity()) else {
         return;
     };
 

--- a/src/ui/city/hud/warehouse.rs
+++ b/src/ui/city/hud/warehouse.rs
@@ -71,7 +71,7 @@ pub fn update_warehouse_display(
         return;
     };
 
-    let Ok(stockpile) = stockpile_query.get(player.0) else {
+    let Ok(stockpile) = stockpile_query.get(player.entity()) else {
         return;
     };
 

--- a/src/ui/city/workforce.rs
+++ b/src/ui/city/workforce.rs
@@ -38,7 +38,7 @@ pub fn spawn_hired_civilian(
         };
 
         // Get capital position
-        let Ok(capital) = nations.get(player.0) else {
+        let Ok(capital) = nations.get(player.entity()) else {
             log_events.write(TerminalLogEvent {
                 message: "Cannot hire: no capital found".to_string(),
             });
@@ -55,7 +55,7 @@ pub fn spawn_hired_civilian(
         };
 
         // Check if player can afford
-        let Ok(mut treasury) = treasuries.get_mut(player.0) else {
+        let Ok(mut treasury) = treasuries.get_mut(player.entity()) else {
             continue;
         };
 
@@ -88,7 +88,7 @@ pub fn spawn_hired_civilian(
         commands.spawn(Civilian {
             kind: event.kind,
             position: spawn_pos,
-            owner: player.0,
+            owner: player.entity(),
             selected: false,
             has_moved: false,
         });
@@ -164,7 +164,7 @@ pub fn handle_recruit_workers_buttons(
         if *interaction == Interaction::Pressed {
             info!("Recruit {} workers button clicked", button.count);
             writer.write(RecruitWorkers {
-                nation: player_nation.0,
+                nation: player_nation.instance(),
                 count: button.count,
             });
         }
@@ -194,7 +194,7 @@ pub fn handle_train_worker_buttons(
         if *interaction == Interaction::Pressed {
             info!("Train worker button clicked: {:?}", button.from_skill);
             writer.write(TrainWorker {
-                nation: player_nation.0,
+                nation: player_nation.instance(),
                 from_skill: button.from_skill,
             });
         }

--- a/src/ui/market.rs
+++ b/src/ui/market.rs
@@ -229,7 +229,7 @@ fn update_market_treasury_text(
         return;
     }
 
-    let Ok(treasury) = treasuries.get(player.0) else {
+    let Ok(treasury) = treasuries.get(player.entity()) else {
         return;
     };
 
@@ -261,11 +261,13 @@ fn update_market_inventory_texts(
         return;
     }
 
-    let Ok(stockpile) = stockpiles.get(player.0) else {
+    let player_entity = player.entity();
+
+    let Ok(stockpile) = stockpiles.get(player_entity) else {
         return;
     };
 
-    let Ok(_allocations) = allocations.get(player.0) else {
+    let Ok(_allocations) = allocations.get(player_entity) else {
         return;
     };
 

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -62,7 +62,7 @@ pub fn update_treasury_display(
     mut q: Query<&mut Text, With<TreasuryDisplay>>,
 ) {
     if let Some(player) = player
-        && let Ok(treasury) = treasuries.get(player.0)
+        && let Ok(treasury) = treasuries.get(player.entity())
     {
         let s = format_currency(treasury.total());
         for mut text in q.iter_mut() {
@@ -153,7 +153,7 @@ pub fn update_tile_info_display(
                     {
                         // Find player's tech
                         for (nation_entity, _, techs) in nations_query.iter() {
-                            if nation_entity == player.0 {
+                            if nation_entity == player.entity() {
                                 let buildable = check_buildability(terrain, techs);
                                 tile_info.push_str(&format!("\n{}", buildable));
                                 break;


### PR DESCRIPTION
## Summary
- replace the custom `NationKind` marker with a `NationInstance` alias backed by `NationId`
- build `PlayerNation` from `World::get_entity` + `Instance::from_entity` instead of `from_entity_unchecked`
- update economy messages to pass the `NationInstance` alias everywhere nations are referenced

## Testing
- cargo fmt
- cargo test
- cargo clippy


------
https://chatgpt.com/codex/tasks/task_b_68f2643ea2e0832fa9661013c074abc8