### PR TITLE
Add diplomacy offers queue and enforce turn gating

### DIFF
--- a/DIPLOMACY_PLAN.md
+++ b/DIPLOMACY_PLAN.md
@@ -1,0 +1,105 @@
+# Diplomacy Implementation Plan
+
+This plan distils the core diplomacy mechanics from the original *Imperialism* manual and adapts them to the current Rust/Bevy codebase. It assumes the present game lacks any AI-controlled diplomatic behaviour or background processing for non-player nations.
+
+## 1. Feature Targets
+
+1. **World overview & information tools** – Provide the player with per-nation intelligence (military strength, economy, relationships, treaty status, trade policies, council votes) before they issue orders.【F:manual_text.txt†L2634-L2710】
+2. **Player-driven diplomatic actions** – Allow issuing orders that resolve at end-of-turn: declarations of war/peace, consulates, embassies, non-aggression pacts, alliances, requests for annexation, and foreign aid.【F:manual_text.txt†L2720-L2869】
+3. **Trade policy controls** – Enable subsidies/boycotts toward nations with consulates, mirroring manual behaviour.【F:manual_text.txt†L2890-L2937】
+4. **Diplomatic offers inbox** – Surface incoming offers (alliances, aid, war demands) and require player responses before advancing turns.【F:manual_text.txt†L2945-L2995】
+5. **Relationship tracking & effects** – Maintain persistent relationship scores and treaty states that unlock actions and influence AI decisions.【F:manual_text.txt†L2634-L2803】
+
+## 2. ECS Data Model
+
+| Concept | Representation | Notes |
+| --- | --- | --- |
+| `NationId` | Existing component | Already used across economy modules.
+| `DiplomaticStatus` | `Component` on a nation entity storing treaties per other nation (`HashMap<NationId, TreatyState>`). | Tracks current war/peace, pacts, alliances.【F:manual_text.txt†L2720-L2847】
+| `RelationshipScore` | `Resource` or component storing per-pair float plus trend flags. | Values drive unlocks (consulate → embassy → pact → annex).【F:manual_text.txt†L2634-L2819】
+| `DiplomaticOrders` | Message queue (resource) containing player-issued commands. | Processed during `Processing` phase.
+| `DiplomaticOffers` | Resource storing incoming prompts requiring UI confirmation. | Populated during `Processing`.
+| `TradePolicy` | Component/resource per nation pair (subsidy/boycott/neutral). | Requires consulate.
+| `ForeignAidLedger` | Resource tracking one-time and locked grants. | Influences relationship trend.【F:manual_text.txt†L2850-L2889】
+
+### Data Flow
+
+1. **PlayerTurn** – UI writes `DiplomaticOrders` (e.g., `OfferAlliance { target }`).
+2. **Processing** – Systems resolve orders, mutate treaty/relationship data, and push `DiplomaticEvent`s (for the log/UI).
+3. **EnemyTurn** – Future AI will populate `DiplomaticOffers` and plan new orders.
+4. **TurnStart** – Clear expired offers, apply ongoing grant payments, decay relationship modifiers.
+
+## 3. Player UI & Interaction
+
+1. **Screen layout** – Follow existing mode overlay pattern (`GameMode::Diplomacy`). Include:
+   - Left tabs for *Information*, *Relationships*, *Trade Policies*, *Council* mirrors manual’s layout.【F:manual_text.txt†L2652-L2710】
+   - Right tabs for *Overtures*, *Grants*, *Trade Policies*, *Offers*.
+2. **Information tab** – Query ECS for selected nation and display: empire size, military strength, favourite trade partner, top exports, treaties. Requires systems aggregating metrics from existing components.
+3. **Relationships map** – Colour-map nations by relationship tier (hostile → allied). Provide legend and text values.
+4. **Treaty overlay** – Render icons/lines indicating wars, alliances, consulates, embassies.
+5. **Orders workflow** – Selecting an action highlights valid targets and shows cost (e.g., $500 for consulate, $5000 for embassy). Permit cancellation before end turn.【F:manual_text.txt†L2720-L2834】
+6. **Incoming offers modal** – When `DiplomaticOffers` non-empty, present dialog queue the player must accept/decline prior to ending the turn.【F:manual_text.txt†L2945-L2995】
+
+## 4. Unlock & Progression Logic
+
+1. **Baseline** – All nations start at peace, with neutral relations (~0).
+2. **Consulates** – Require neutral or better relations and $500. Unlocks trade policy controls and enables relationship gain from trades.【F:manual_text.txt†L2768-L2779】
+3. **Embassies** – Require consulate, relationship threshold (e.g., ≥30), and $5000. Unlocks pacts, aid, entry for civilians, annex requests.【F:manual_text.txt†L2780-L2790】
+4. **Non-aggression pact** – Free, requires embassy. Grants relationship boost and prevents offensive orders unless broken.【F:manual_text.txt†L2794-L2803】
+5. **Alliances** – Great Powers only, require embassy and positive relations (≥40). Establish mutual defence triggers; refusal hurts trust.【F:manual_text.txt†L2821-L2843】
+6. **Join Empire** – Available when relationship ≥70 (Minor Nations) or target is desperate (Great Powers). Success converts to `Colony` status, transferring assets.【F:manual_text.txt†L2804-L2849】
+7. **Foreign aid & subsidies** – Select amount ($100–$10,000) per turn; locked grants auto-repeat. Increase relationship over time proportional to cumulative spend.【F:manual_text.txt†L2850-L2931】
+8. **Trade policies** – With consulate, allow subsidy/boycott toggles affecting trade resolution and relationships.【F:manual_text.txt†L2890-L2937】
+
+## 5. Relationship Mechanics
+
+1. **Score range** – Use `-100..=100` with named bands (`Hostile`, `Unfriendly`, `Neutral`, `Cordial`, `Warm`, `Allied`).
+2. **Events** – Adjust scores based on actions: war declarations, aid, trades, treaties, betrayals. Derive modifiers from manual descriptions (e.g., breaking pacts causes global penalty).【F:manual_text.txt†L2634-L2995】
+3. **Decay** – Each turn, drift toward neutral while preserving locked modifiers (pacts, aid). This models “benefits build over time”.【F:manual_text.txt†L2639-L2889】
+4. **Visibility** – Player sees numeric & qualitative values; AI uses thresholds to decide offers in future.
+
+## 6. Turn Resolution Rules
+
+1. **Order queue resolution** – Evaluate overtures in deterministic priority: peace/war → treaties → consulates/embassies → aid → annexation. Prevent contradictory states.
+2. **Simultaneous execution** – When multiple nations act, apply to cached state then commit to maintain fairness. Use reservation-like approach mirroring resource allocations.
+3. **War consequences** – On declaration, set `War` status, reduce relationship by large amount, adjust global modifiers based on victim’s friends/enemies.【F:manual_text.txt†L2733-L2754】
+4. **Peace** – Available once war active; acceptance conditions determined by future AI heuristics. For now, allow player to force acceptance for Minor Nations; Great Powers accept only if simulated evaluation deems favourable (placeholder: check comparative military strength & capital threat).【F:manual_text.txt†L2752-L2756】
+5. **Council votes** – Track colonies and allied influence to integrate with victory conditions later.【F:manual_text.txt†L2804-L2815】
+
+## 7. AI Placeholder Strategy
+
+Because no AI framework exists yet:
+
+1. **Deterministic scripts** – For MVP, define rule-based reactions (e.g., auto-accept consulates, embassies) mirroring manual assurances.【F:manual_text.txt†L2768-L2799】
+2. **Future hooks** – Provide trait `DiplomacyAgent` with callbacks (`evaluate_offer`, `plan_orders`) so AI modules can plug in later.
+3. **Simulation stubs** – Implement simple evaluation functions (trade value, military strength) to power acceptance checks.
+4. **Testing harness** – Add unit tests for acceptance logic and order resolution without needing full AI opponents.
+
+## 8. Implementation Phases
+
+1. **Scaffolding** – Define data components/resources, register systems in `src/lib.rs`, ensure serialization for saves.
+2. **UI foundation** – Build diplomacy screen overlay with tab navigation; integrate with existing Bevy UI patterns.
+3. **Order handling** – Implement message structs and processing systems for each overture type.
+4. **Relationship engine** – Create modifier framework (per-turn adjustments, event-driven deltas).
+5. **Offer inbox** – Build UI + logic for incoming offers, log events, and blocking end-turn until resolved.
+6. **Trade policy integration** – Connect subsidies/boycotts to market logic once Market v2 work begins.
+7. **Testing & balancing** – Write unit/integration tests for order resolution, relationship transitions, and UI state. Add debug visualization for relationships to speed tuning.
+
+## 9. Risks & Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Complexity explosion without AI | Keep MVP deterministic, deferring dynamic AI decisions until dedicated system exists. |
+| Data duplication between treaties & relationships | Encapsulate in a single `DiplomaticState` struct per nation pair. |
+| UI clutter | Follow manual’s tabbed layout and reuse existing UI components. |
+| Save-game compatibility | Version structs and add migration path early. |
+| Integration with victory conditions | Expose colony/alliance changes through events to update council logic. |
+
+## 10. Success Criteria
+
+- Player can inspect any nation, view relationships, and issue diplomatic orders each turn.
+- Orders resolve consistently at end of turn and update treaties/relationships.
+- Incoming offers block end turn until decisions are made.
+- Relationship tiers gate advanced actions (embassy, pact, alliance, annex).
+- Systems emit events for UI/log and are test-covered.
+

--- a/manual_text.txt
+++ b/manual_text.txt
@@ -1,0 +1,4169 @@
+--- page 1 ---
+
+--- page 2 ---
+I M P E R I A L I S M :
+A G AME OFSTRATEGIC WORLD CONQUES T
+THROUGH
+ECO NO M I C , DI P LO M AT I C ,
+A N DMI L I TA R YME A N S
+FEATURIN G
+NAT I O NA L I S TIC INDUSTRIAL DEVEL O P M E N T , AND 
+THE EXPL O I TATION OF MINOR POWERS 
+AND NATURAL RESOURCES FOR 
+THE GL O RY OF YOUR EMPIRE
+PRESENTED B Y
+FRO GCI TY
+AND
+ST R AT E G I C SI M U L AT I O N S , INC.
+--- page 3 ---
+INTRODUCTION  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 1
+Fast Start . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 1
+Copy Pr otection . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 2
+Using the Mouse for Windows . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 2
+Using the Mouse for Macintosh . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 2
+Autosa ve . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 2
+STARTING A GAME  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 3
+How to Begin a Game . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 3
+HOW TO GET HELP  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 7
+Minis ter Briefings  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 7
+Warnings from Minis ters . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 9
+The Help and Information Dialog  . . . . . . . . . . . . . . . . . . . . . . . . . . . . 9
+Other Help  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 10
+IMPERIALISM BASICS  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 11
+How to Rule Your Empir e . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 11
+Order of Actions Within a Tur n . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 12
+Countries in IMPERIALISM  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 13
+Control of Pr ovinces  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 14
+How to Win . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 15
+How the Economy Wor ks . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 15
+Saved Games . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 17
+WHAT HAPPENS ON THE TERRAIN MAP  . . . . . . . . . . . . . . . . . . . . . . 18
+Establishing a Capital City . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 18
+The Map . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 18
+Terrain Map Screen Toolbar  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 20
+The Cycle of Units . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 21
+Map Cursor s . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 22
+Civilian Units  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 23
+Land Forces . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 32
+Naval Units  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 38
+THE TRANSPORT NET WORK  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 44
+What is the Transport N etwork? . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 44
+Using the Transport N etwork . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 46
+Possible Commodities to Transpor t . . . . . . . . . . . . . . . . . . . . . . . . . . . 47
+INDUSTR Y . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 50
+What is Industry? . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 50
+Using the Warehouse . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 51
+Labour  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 52
+Building Units  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 55
+Building Industr y . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 57
+Expanding Industr y . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 58
+Giving Orders to Industr y . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 59
+Building Transport Capacity  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 60
+TRADE  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 61
+What is Trade?  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 61
+Giving Trade Order s . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 64
+Merchant Marine  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 66
+Receiving Trade Of fers . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 67IMPERIALISM: Contents
+--- page 4 ---
+DIPLOMACY  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 71
+What is Diplomacy? . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 71
+Using the Diplomacy Screen for Information  . . . . . . . . . . . . . . . . . . . . 71
+Diplomatic Overtures . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 73
+Foreign Aid and Briber y . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 77
+Trade Policies  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 78
+Receiving a Diplomatic Of fer . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 80
+FIGHTING B ATTLES  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 82
+Battles and Reports  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 82
+Tactical Land Battles . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 83
+TECHNOLOGICAL AD VANCES  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 88
+Receiving a N otice of N ew Technology . . . . . . . . . . . . . . . . . . . . . . . . . 88
+Technology In vestment Screen . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 88
+Confirmation of an In vestment  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 90
+HISTORICAL SCENARIOS  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 91
+The Reco very of France 1820 . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 91
+Unification Mo vements 1 848-1890 . . . . . . . . . . . . . . . . . . . . . . . . . . . . 92
+Naval Competition 1882-End of the Game . . . . . . . . . . . . . . . . . . . . . . 92
+TUTORIAL WALK THROUGH  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 93
+Tutorial Using Civilian Units  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 93
+Tutorial Using Military Units . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 97
+Tutorial for Using N aval Units  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 99
+Tutorial for Using the Transport Screen . . . . . . . . . . . . . . . . . . . . . . . . 101
+Tutorial For Using the Industry Screen . . . . . . . . . . . . . . . . . . . . . . . . . 102
+Tutorial For Conducting Trade  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 105
+Tutorial For Using the Diplomacy Screen . . . . . . . . . . . . . . . . . . . . . . . 108
+HOT KEY LIS T . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 111
+STRATEGY IDEAS  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 112
+Tips For the De velopment Phase  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 112
+Tips For the Diplomacy Phase . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 113
+Tips For the Destruction Phase  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 113
+FROG CITY CREDIT S . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 114
+SSI CREDIT S . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 114
+BIBLIOGRAPHY  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 115
+LIST OF TABLES
+Terrain Tiles Table  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 19
+Command Cursors Table . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 22
+Selection Cursors Table  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 23
+Information Cursors Table . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 23
+Resource De velopment Table . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 25
+Regimental Upgrade Requirement Table  . . . . . . . . . . . . . . . . . . . . . . . 33
+Warship S tatistics Table  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 41
+Production Economies Table  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 52 
+Industrial Input and Output Table . . . . . . . . . . . . . . . . . . . . . . . . . . . . 60
+Regiment Abilities Table  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 87
+Benefits of Technology Table  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 89 IMPERIALISM: Contents
+--- page 5 ---
+INTRODUCTION 
+In I M P E R I A L I S M you rule one of the Great Pow e rs in a w o rld modelled on the r e a l
+wo rld of the ninet e e n th century. As the game begins, your country and the ot h e r
+Great P owers begin a period of rapid economic, militar y, and social advancement
+due to the onset of the Industrial R evolution. You must fir st harness these his toric
+fo rces to develop your own country, and then use your new found w e a l th and
+re s o u r ces to com p ete successfully with the other Great Pow e rs in the realms of
+d i p l o m a c y , trade, and w a r. Only one Great Power can establish the pr e - e m i n e n t
+Empire in the world.
+To start playing IMPERIALISM right a way, try the “ Tutorial Walk Through” sections
+starting on page 93. Ho wever, if you want to s tart your own game without fur ther
+reading, follow these steps for a fast start:
+Fast Start.
+1. Double click on the game icon to s tart the game. (In Windo ws® 95 you can also
+start from the Prog rams menu). When the introductory sequence ends, you are on
+the I MPERIALISM screen, which depicts an office. 
+2. Click on the Globe on the desk of the Office screen.
+3. In the Map R o o m , wait for the globe to stop spinning, then either accept t h e
+p re - s e l e c t ed country or choose a diff e rent coloured country on the large map by
+clicking on the map itself.
+4. Select Introductory as the difficulty level.IMPERIALISM: Introduction 1
+CONTENTS
+High Pressure S team Engine. James Watt de veloped the fir st efficient s team engines. Later
+improvements of the s team engine made railroads possible, r evolutionising transpor tations.
+--- page 6 ---
+5. Click on the Start Game button.
+6. You are now playing Im p e rialism. Each new screen, st a rting with t h e
+n ews p a p e r , includes a br i e fing from one of your Minist e rs. These br i e fings 
+appear automatically at the Introductor ylevel of pla y, and using the Preferences screen
+you may choose to have these br i e fings appear aut o m a t i c a l l y when playing at
+other levels of diff i c u l t y . Oth e rwise, click on the H e l p b u t ton in the upper - ri g h t
+c o rner of the screen to open the Help and Inf o rm a t i o n menu. Move the mouse
+c u rsor over the options pr e s e n t ed to locate the A d v i c e b u t ton. Click on A d v i c e to
+b ring up a Minister Br i e fing for that screen. Use these br i e fings to get going. F o r
+more information on using the “Minister Briefings” see page 7.
+Copy Pr otection.
+In order to play I MPERIALISM , the game CD must be in your CD-ROM drive.
+Using the Mouse for Windo ws.
+In the W i n d o ws® 95 v e rsion of I M P E R I A L I S M , to “click” inv o lves moving t h e
+mouse pointer to the desired area on the screen and pressing the left mouse button.
+O c c a s i o n a l l y, you may also need to “inf o - c l i c k .” There are two ways to inf o - c l i c k ,
+e i ther by right-clicking or shift-clicking. Right-clicking means moving the mouse
+p o i n t er to the desired area and pressing the right mouse button. Shif t - c l i c k i n g
+means moving the mouse pointer to the desired area, holding down Shiftkey and
+pressing the left mouse button.
+Using the Mouse for Macintosh.
+In the Macintosh v e rsion of I M P E R I A L I S M , the t e rm “click” means moving t h e
+mouse pointer to the desired area on the screen and pressing the mouse butt o n .
+On the Macintosh, “info-click” is the same as “shif t - c l i c k .” Shift-clicking means
+m oving the mouse pointer to the desired area, holding down S h i f tkey and
+pressing the mouse button.
+Autosave.
+As you play I M P E R I A L I S M , your game is saved aut o m a t i c a l l y at the beginning of
+e a ch new turn while you are reading the new s p a p e r . Loading this game t a kes yo u
+back to the beginning of your turn. If you want to save prior to executing y o u r
+o rd e r s, but after your or d e rs are ent e red, you must save the game y o u rself dur i n g
+the turn to one of the other save slots. For more inf o rmation on saving games and
+the Autosave feature, see the “Saved Games” section, starting on page 17.IMPERIALISM: Introduction 2
+CONTENTS
+--- page 7 ---
+STARTING A GAME
+How to Begin a Game.
+The I M P E R I A L I S M s c reen depicts your office. From where you are sitting, you can
+decide to play on a new r a n d o m l y ge n e ra t ed w o rld by clicking on the G l o b e .
+Clicking on the B o o k a l l ows you to select a hist o rical scenario. To load a sav e d
+game, click on the Ship in the Bo t t l e. The Te l e p h o n e p rovides access to
+M u l t i p l a yer games, including st a rting and hosting new games, joining a new
+game, or restoring a saved multiplayer game.
+You can exit I MPERIALISM by clicking on the Doorway out of the room.
+Random Worlds.
+When you click on the G l o b e on the Im p e rialism screen you depart your off i c e
+for the Map R o o m . As you enter the Map R o o m , the large globe on the pedest a l
+is spinning to indicate that a new w o rld is being g e n e ra t ed. When the w o rld is
+c o mp l e te a map appears on the right side of the Map R o o m s c reen. The map
+s h ows the political boundaries of the countries. Your Great Power is outlined in
+white and its coat of arms appears below the globe. If you prefer to play a dif ferent
+G reat Pow e r, make that choice with a click on that country on the map. Gr e a t
+Powe rs appear in colour; the other countries are Minor Nations. When y o u
+ch a n g e countries, a new coat of arms appears below the globe. If you do not like
+the look of the w o rld, click on the globe to g e n e ra t e a new one. When you have a
+G reat Power selection, choose one of the f i ve difficulty settings listed below t h e
+map. The name of your Great Power can be c h a n g ed sim p ly by clicking in t h e
+name field and typing the new name.
+When you ha ve a world map, a Great P ower selection, and a dif ficulty setting you
+are satisfied with, click on the Start Game button to begin.
+To exit this screen and re t u rn to the I M P E R I A L I S M s c reen without st a rting a new
+game click on the Doorway out of the Map Room .IMPERIALISM: Starting a Game 3
+CONTENTS
+
+--- page 8 ---
+Scenarios.
+When you click on the B o o k you leave the I M P E R I A L I S M s c reen for the Libr a ry
+s c reen. On the left side of the screen, you may select scenarios to play. When y o u
+select a scenario, a description of the general situation appears under the scenario
+s e l e c to r , and a map appears on the right side of the screen. For det a i l e d
+information, see the “Historical Scenarios” section, starting on page 91.
+You can re t u rn to the office without st a rting a scenario by clicking on t h e
+Doorway out of the room.
+Multipla yer.
+Click on the Te l e p h o n e to go to the C o n fe r ence R o o m . On this screen you f i rst
+select the protocol, or connection method, for your multiplayer game. Once t h e
+p roper method is highlighted, you may decide to join someone else’s game by
+clicking on the Tea Ser v i c e. To host a game of your own click on the G l o b e , th e
+Book or the Bottle . Each of these represents a dif ferent type of game you can host. 
+Joining a Multipla yer Game.
+Once you select a game to join you enter the Multipla yer Loung e, which includes
+a map display of the game you chose to join. In the f o re g round of the screen are
+seven panels displaying the coats of arms of the seven Great Powers in the game.
+T o select which Great Power you want to play, you can either click on the map, or
+on the wooden panel for that pow e r. Any panel with a com p u ter icon is available. If
+the panel has a green check mark, another player has already selected that country. 
+Hosting a Multipla yer Game.
+If you are hosting a game, you leave the multiplayer C o n fe r ence R o o m a fte r
+selecting which type of game to host: 
+• a new game on a random world by clicking on the Globe
+• a new scenario by clicking on the Book
+• a saved game by clicking on the Bottle
+E a ch of these options st a rts up a game in the same way as the solit a i re play g a m e
+of the same type, except that other players are able to join the game you begin.
+Once you ha ve created (or loaded) your game you enter the Multipla yer Loung e.
+As host, you choose your Great P ower fir st, and then wait while o ther pla yers join
+your game by selecting their Great Pow e rs. Wait until ev e rybody has joined up,
+and then you, as host, click the Begin Game button to start the game. IMPERIALISM: Starting a Game 4
+--- page 9 ---
+Difficulty Settings.
+There are five dif ficulty settings. Whene ver a new game on a random map begins,
+a difficulty setting must be selected; N o rm a l is the default. Scenarios aut o m a t i c a l l y
+include a difficulty setting det e rmined by the situation facing the play e r’s Gr e a t
+Power in that scenario. When difficulty settings are selected by the play e r, each
+s etting establishes a diff e rent relationship be t ween the st a rting potential of t h e
+G reat Pow e rs played by humans com p a red to the potential of those Great Pow e rs
+played by computer AI. P otential is controlled by varying diplomatic relationships,
+commodities available in the w a rehouse, and the size of the armed f o rces at t h e
+start of the game.
+Introductory Setting.
+Minis ter advice, warnings, and briefings are all active. You do not select your own
+c a p i t al city sites, and all your f a c to r ies and mills are cons t ru c t ed in advance. In
+addition, all milit a ry units have been told to D e f e n d . Thus, you are not r e qu i r ed to
+g i ve ord e rs to the milit a ry at the st a rt of the game. F i n a l l y, you and any ot h e r
+human play e rs in the game r e c e i v e adv a n ta g es over the AI in economic and
+diplomatic fields. 
+Economic adv a n ta g es include the number of mineral r e s o u r ces lik e ly to be f o u n d
+in your country and the amount of commodities (r e s o u r ces, mat e rials, and goods)
+in your warehouse at the start of the game.
+Diplomatic adv a n ta g es include be t ter relationships with certain of the Minor
+Nations. This provides you with a head start in trade and diplomacy.
+Easy Setting.
+This setting includes most of the effects provided by the I n t ro d u c t o r ys etting. One
+d i ffe rence is that the Minister Briefings do not aut o m a t i c a l l y appear. If you want to
+read a br i e fing you must access it t h rough the help and inf o rmation dialog by
+clicking on the Helpbutton. The diplomatic advantages pr ovided by the Introductor y
+s etting are not included on the E a s y s etting, but the economic adv a n ta g es are
+included.
+Normal Setting.
+You establish your own capital city’s site on the N o rm a l s etting. This provides more
+c o n t r ol over the r e s o u r ces available at the st a rt of the game. In addition, y o u
+decide which f a c to r ies and mills to cons t ruct on your f i rst turn given the limit e d
+commodities available in your warehouse. 
+None of the Great Powers have any special advantages on this setting.
+Hard Setting.
+As on the N o rm a l s etting, you establish your own capital city’s site and decide 
+w h i c h fa c to r ies and mills to cons t ruct on your f i rst turn given the limit e d
+commodities available. 
+You are faced by computer pla yers with bo th economic and diplomatic advantages
+similar to those given humans on the Introductory setting.IMPERIALISM: Starting a Game 5
+--- page 10 ---
+“Nigh-On Impossible” Setting.
+As with the N o rm a l s etting, you establish your own capital city site and decide 
+w h i c h fa c to r ies and mills to cons t ruct on your f i rst turn given the limit e d
+commodities available. 
+You are faced by computer pla yers with bo th economic and diplomatic advantages
+similar to those given humans on the Introductor ysetting. Additionall y, the AI enjo ys
+a large milit a ry super i o rity over any human bold (or foolish) enough to play on
+this setting.
+Preferences.
+To set pr e fe rences, click on the Game Contr o l sb u t ton at the top right corner of t h e
+Terrain Map screen. This button has a small computer icon on it. F rom the game
+controls screen, click on the Set Preferences button.
+The Pr e fe rences screen saves your selections so that next time you play, t h e
+p re fe r ences remain set. When each pr e fe rence is on, its graphic is lit, and when it
+is off, the graphic is dark. Some buttons such as sound and music have
+intermediate levels. The following options are available: 
+Warnings.
+You can turn off only non-dire w a rnings. Your Minist e rs wa rn you about dire
+events such as an upcoming attack on the capital r e ga r dless of your pr e fe re n c e s .
+Turn this preference off if you do not need Minis ter reminders about matters suc h
+as w a sting tr a n s p o r t capacity or failing to purchase t e ch n o l o g y . For more
+information, see the “Warnings from Ministers” section, starting on page 9. 
+Briefings.
+Click on this pr e fe rence to see br i e fings on ev e ry screen. Of course, even with t h e
+p re fe r ence off, you can access the br i e fings t h rough the Help and Inf o rm a t i o n
+dialog. For more inf o rmation, see the “Minister Br i e fings” section, st a rting on
+page 7.
+Sound and Music.
+These buttons allow you to set volume. Drag the mouse up and down while
+p ressing the mouse button to raise and lower volume. If the entire button is dark,
+the volume is completely muted.
+Tactical or Strategic Battles.
+When the battles pr e fe rence is set to tactical resolution, indicated by the image of
+cannon, each battle you fight t a kes place on a battlefield where your r e g i m e n t s
+m a n o e u v r e individually ag a i n st those of the enemy. If this pr e fe rence is set to
+st ra tegic resolution, indicated by a medal, the f o rces are totalled and a r e s u l t
+d i s p l a yed when you click the End T u rnb u t ton. For more inf o rmation see t h e
+“Fighting Battles” section, starting on page 82.IMPERIALISM: Starting a Game 6
+--- page 11 ---
+HOW TO GET HELP
+On all game screens where you make decisions, a Helpbutton appears in the upper -
+right of the screen. 
+On the Te rrain Map s c reen or one of the Or d e rs screens, click on this button to
+b ring up the Help and Inf o rm a t i o n dialog. This dialog provides sev e ral op t i o n s
+including advice or a Briefing from one of your Minis ters, r eviews of trade, battles,
+news, and a status comparison of the Great Powers. 
+On other screens some of these options are not available. When you click the H e l p
+b u t ton you jump dir e c t ly to Minister Advice or Br i e fings for the screen you are on.
+The other control common to almost all screens is the L e ft Arrow s y m b o l .
+Clicking on this control closes the current screen. During a turn it re t u rns you 
+to the Te rrain Map . During the transition be t ween turns it advances you to 
+the next screen
+Minister Briefings.
+If you play with the Br i e fings pr e fe rence on, you r e c e i v e Minister Briefings at th e
+beginning of your turn on each game screen. The br i e fings provide basic
+information on several topics for each new screen.
+Additional br i e fings are provided for more com p l ex screens, but you r e c e i v e only
+one br i e fing each turn until all the br i e fings for that screen are issued. You can access
+p a st bri e fings using the P revious Briefing h i g h l i g h t ed text on the br i e fings dialog.
+Using the Briefings.
+In each briefing dialog you see the title of the briefing and a list of blue underlined
+topics. Click on a topic, and the list of topics is replaced by text about the t o p i c
+you selected. Once you ha ve read all the information, click on Show Topics again t o
+return to the selection of topics for the briefing.
+When you are learning to play, the br i e fings are best used by reading about one
+activity or inter face and then putting the briefing aside while you try out what you
+have just read. Since the briefings are floating windo ws, you can lea ve the windo w
+open, do some thing on the screen, and then r eturn to the briefing to read about a
+d i ffe rent activity. If you close the br i e fing window, you can easily bring it back by
+clicking on the Helpbutton.
+The f i rst topic on a br i e fing window provides an introduction and g e n e ra l
+i n fo r mation about the screen. The second topic often provides a more det a i l e d
+look at the items displayed on the screen. The t h i rd topic usually pro v i d e s
+i n st r uctions on giving or d e rs. The last two topics, if available, offer tips for g a m e
+p l ay on the screen. Sometimes one or more of these topics are not pr e s e n t ; fo r
+example, if no orders can be given, there is no “Giving Orders” topic.IMPERIALISM: How to Get Help 7
+CONTENTS
+--- page 12 ---
+Example: Using a Briefing.
+At the beginning of your f i rst turn on the Te rrain Map s c reen, your Int e ri o r
+M i n i s ter supplies a br i e fing titled Te rrain Map Briefing #1 . Read the f i rst topic, titled
+About Civilians . You learn that civilian units de velop resources on the map. Click on
+Show Topics again.
+In the toolbar you see a unit called a Prospector, and you see the same unit with a
+flashing white outline on the map. Click on the topic Displayed Infor m a t i o n and r e a d
+about unit selection. You learn that this Pr o s p e c t or is the selected unit. Click on
+Show Topics again.
+The topic titled Giving Or d e r s l ets you know that you can e x p e r iment with
+commanding your units by clicking on the map when a unit is selected and t h a t
+you can cancel the command if you wish, up until the end of the turn.
+Fo l l owing these ins t ructions, click on sev e ral diff e rent-looking pieces of t e rrain and
+then cancel each order if the unit fails to st a rt doing an y thing t h e re. Y ou may no t i c e
+that diff e rent cur s o rs appear as you move your mouse over diff e rent te rrain. T o learn
+about these cursor c h a n g es, re t u rn to the br i e fing and click on Show T o p i c s a ga i n .
+Click on What do dif f e rent cursors mean? . You learn that the “Eye” cursor shows where a
+P ro s p e c t or can w o rk. Re t u rn to the t e rrain map and click on a barren hill t e rra i n
+w i th the “Eye” cur s o r. The Pr o s p e c t or begins looking for minerals in that tile.IMPERIALISM: How to Get Help 8
+Ironclads. Although Great Britain & F rance built the world’s fir st two seagoing ironclads, it took the
+American Civil War to pr ove ironclads’ superiority o ver wooden ships.
+--- page 13 ---
+Warnings from Ministers.
+When one of your Minist e rs believes your or d e rs may lead to unf o rt u n a t e re s u l t s ,
+he provides a w a rning. A dialog including your countr y ’s coat of arms and a
+picture of the Minis ter appears o ver the screen. The Minis ter explains the situation
+and often provides sugg e sted c h a n g es to your or d e rs. You can always choose to
+ignore the warning; af ter all, you rule the Great P ower. In fact, on the Preferences
+screen you can disable many of the warnings entirely.
+S o m e times the Minist e rs do not know all the facts of the situation. For ex a mp l e ,
+your Int e rior Minister may r e p o r t that your tr a n s p o r t ord e rs are going to lead to
+sta rvation of indus t rial w o rke rs. You may know that your f o reign trade is going to
+bring in canned food to deal with the situation. It might be a mis take to follow the
+Minister’s suggestions blindly. 
+The most dire warnings in volve the saf ety of the capital. If you lose the capital you
+lose the game.
+The Help and Information Dialog.
+For help click on the H e l p b u t ton from Or d e rs screens and the Te rrain Map
+s c reen. The Help b u t ton is found in the upper right of the screen. The Help and
+Information dialog which pops up provides several options for obtaining help.
+Advice from Minis ters.
+Your t h ree Minist e rs (Defence, Int e ri o r , and F o reign) have a lot to say. You can
+ask them for help by clicking the A d v i c e b u t ton in the Help and Inf o rm a t i o n
+dialog, which brings up the br i e fing window. Each Minister is also responsible f o r
+popping up to w a rn you about issues within that Minist e r’s por t folio that may
+require your attention. 
+Reading the News.
+The newspaper appears at the st a rt of ev e ry turn. Click on the N e w s p a p e r b u t to n
+on the Help and Inf o rm a t i o n dialog to re v i ew headlines for this turn. Gener a l ly,
+a story that of fers information, pr ovides a warning, or af fects the play of the game
+a p p e a r s under a bold headline. Of course, as a wise ruler you should become
+a c qu a i n t ed with all the new s wo r thy doings of the little people who make up y o u r
+country’s population.
+Battle Reports.
+You r e c e i v e a battle r e p o r t after you end the turn in which a battle t a kes place.
+O ften, especially in a multiplayer game, you are not going to have enough time
+b et w een turns to re v i ew all the details in the r e p o r t. If you want to look at t h e
+re p o r t again during your turn, click on the Battle Repor t sb u t ton on the Help and
+I n fo rm a t i o n dialog. For more inf o rmation see the “Battles and R e p o r ts” section,
+starting on page 82.IMPERIALISM: How to Get Help 9
+CONTENTS
+--- page 14 ---
+The Deal Book .
+W h e n e ver you click the End T u rnb u t ton, trade deals are made be t ween your Gr e a t
+Power and other countries. After all deals have been made, a summary called t h e
+Deal Book a p p e a r s for your re v i ew bef o re the next turn st a rts. During your tur n ,
+you might want to r eview these deals again, especially in a multipla yer game wher e
+other play e rs may urge you to move swif t ly to the next turn when the Deal Book
+is fi rst shown. Click on the Deal Book b u t ton for a re v i ew. For more on how to
+read the Deal Book see the “Deal Book” section, starting on page 69.
+Game S tatus.
+The S t a t u s b u t ton on the Help and Inf o rm a t i o n dialog t a kes you to the St a t u s
+s c reens — which are v a rious c h a rts com p a ring the Great Pow e rs. On the scr e e n ,
+you click on tabs to the sides of the c h a rt to look at diff e rent st a t i stics. You can
+c o mp a r e your countr y ’s perf o rmance ag a i n st the other Great Pow e rs in M e rc h a n t
+M a r i n e , World Expor t s, I n d u s t r y, L a b o u r , Overseas Pr o f i t s, and Tr a n s p o r t. Ad d i t i o n a l l y, th e
+Council Pr o j e c t i o n re p o r t combines milit a ry st re n g t h, diplomatic s t re n g t h, and t h e
+internal strength and size of each Empire to rate the Great P owers. The two Great
+Powe rs at the top of this c h a rt would be nominated for vict o ry by the Council of
+G ove rn o r s if a meeting w e re held this turn. The t h ree components of the C o u n c i l
+Projection may be vie wed individually using the three tabs directly below the Council
+Projection tab. 
+Other Help.
+Info-Click .
+On the Te rrain Map s c reen you can often obtain more inf o rmation about
+s o m e thing with an info-click on it. This is the best way to get the facts on a
+particular terrain tile. Each item in the tile has a separate definition.
+Hot T ext.
+In the upper - right part of most screens, text is displayed as you move your mouse
+c u rsor across the screen. You can obtain useful, and brief, inf o rmation by placing
+the cursor over an icon, picture, or other object you are w o n d e r ing about. F o r
+exa mple, on the I n d u st r ys c reen hot text identifies each building and on the B i d
+and Off e rss c reen hot text identifies each commodity. Most items in the T e rra i n
+Map toolbar are defined here. On the Tra n s p o r ts c reen hot text identif i e s
+commodities, and shows industrial usage of them.IMPERIALISM: How to Get Help 10
+CONTENTS
+--- page 15 ---
+IMPERIALISM BASICS
+IM P E R I A L I S M is a turn-based game in which you rule one of the w o rl d ’ s Gr e a t
+Powe rs. Each new turn begins with a newspaper summarising the key events of
+the past three months. 
+Once you have read the new s p a p e r , you go to the Te rrain Map s c reen, y o u r
+c e n t r al command centre. During your turn you command your milit a ry and
+civilian units, f a c to r ies, tr a d e r s, diplomats, and w a rships as do the r u l e rs of t h e
+other Great P owers. The rulers of each Great P ower, be they a human pla yer or a
+computer player, enter their orders simultaneously.
+When all r u l e rs have ended their turns, the commands ent e red by each Gr e a t
+Power during that turn are car ried out simultaneousl y. Each turn represents three
+months. Most games consist of about 400 turns, though, of course, one pla yer ma y
+win before this time.
+How to Rule Your Empire.
+You gov e rn your Em p i re using f i ve screens: a central Te rrain Map s c reen and
+four Orders screens accessed from the T errain Map.
+Introduction to the Ter rain Map Screen.
+The Te rrain Map s c reen is your command centre and consists of a map of t h e
+world and a toolbar. Each turn begins and ends on the Terrain Map screen. Her e
+you access game controls to save your game or st a rt a new one, set g a m e
+preferences, and manage all your military and civilian units. For de tails on how t o
+use the Terrain Map screen see the “What Happens on the Ter rain Map” section,
+starting on page 18. 
+Introduction to the Orders Screens.
+From the Te rrain Map s c reen you access four O rd e r ss c reens called t h e
+Tra n s p o r t, I n d u st r y, Bid and Off e rs, and D i p l o m a c y s c reens. You need not use
+all these screens ev e ry turn; you may find y o u rself spending more time on I n d u st r y,
+for ex a mple, than you do on D i p l o m a c y . Your ov e rall st ra tegy for winning t h e
+game det e rmines which of these O rd e r ss c reens you need to use the mos t .
+Transport Screen.
+This is where you order commodities to be moved from the r u ral and
+mining dis t ricts of t e rri to ries you rule to the indus t rial centres where t h e
+commodities can be used. Each turn, when you click the End T u rnb u t to n
+on the Te rrain Map s c reen , the commodities you or d e red tr a n s p o r ted move to
+the w a rehouse in the I n d u st r ys c reen for use during the next turn. For more
+information see the “Transport Network” section, starting on page 44. IMPERIALISM: IMPERIALISM Basics 11
+CONTENTS
+--- page 16 ---
+Industry Screen.
+This is where commodities you tr a n s p o r t and commodities you trade f o r
+are used to produce more expensive or useful commodities. You also build
+all your units on this screen. Each turn, when you click the End Tur nbutton
+on the Te rrain Map s c reen, all the production or d e rs you ent e red on this scr e e n
+a re carried out. The things you build are available next turn. For more
+information see the “Industry” section, starting on page 50. 
+Bid and Of fers Screen.
+This is where you offer commodities for sale and enter bids f o r
+commodities you hope to buy. Each turn, when you click the End T u rn
+button on the Terrain Map screen, you may receive of fers to buy some or
+all of the items you bid on. The items you off e red for sale may be sold to ot h e r
+c o u n t r ies. If you accept an offer to buy, the commodities you bought appear f o r
+your use on the I n d u st r ys c reen during your next turn. Commodities you sell are
+d e d u c t ed from the w a rehouse on the I n d u st r ys c reen. For more inf o rmation see
+the “Trade” section, starting on page 61.
+Diplomacy Screen.
+This is where you view information about the o ther countries in the game,
+declare war, take diplomatic initiatives, set trade policies, and g rant foreign
+aid. Each turn, when you click the End T u rnb u t ton on the Te rrain Map
+s c reen, the policies you set are carried out. If you off e red a treaty to anot h e r
+c o u n t r y, its ruler accepts or rejects your off e r. If another country off e red you a
+treaty or pact, you act on it. Any changes in diplomatic s tatus take ef fect next turn.
+For more information see the “Diplomacy” section, starting on page 71. 
+Order of Actions Within a Turn.
+When all Great Pow e rs have ended their turns the series of commands are always
+carried out in the same order: 
+• Diplomatic offers are exchanged, and either accepted or rejected.
+• Trade deals are offered, and accepted, or rejected.
+• Industrial production takes place.
+• Military conflicts are resolved.
+• Intercepted or blockaded trades are cancelled. 
+• All commodities tr a n s p o r ted int e rn a l l y, or successfully deliv e red by tr a d e r s, are  
+placed in the industrial warehouse for use on the next turn.
+Cancelling Orders.
+On the Te rrain Map s c reen the End T u rnb u t ton appears in the lower right. U n t i l
+you click this button, you can cancel any of the or d e rs you have ent e red. Not h i n g
+is permanent until you click the End Turn button.IMPERIALISM: IMPERIALISM Basics 12
+CONTENTS
+--- page 17 ---
+Countries in Imperialism.
+In I M P E R I A L I S M th e re are two types of countries. The f i rst type, Great Pow e rs, are
+actors in the game, each ruled by a human or by a wily computer foe. The second
+type, Minor Nations, serve as regions for e x p l o i t ation and battle by the Gr e a t
+Powe rs. A Minor Nation in I M P E R I A L I S M c a n n o t develop into a Great Pow e r, nor
+can it win the game. 
+Both Minor Nations and Great P owers may be conquered by o ther Great P owers.
+When part of a country is t a ken by conq u e st it becomes part of the conq u e ri n g
+G reat Pow e r. The country that lost the land is smaller. Both Great Pow e rs and
+Minor Nations can be eliminated from the game by conquest.
+Minor Nations can be colonised by Great Pow e rs. In I M P E R I A L I S M , colonisation
+refers to a “peaceful” takeo ver that could be the result of economic po wer over the
+Minor Nation, br i b e ry of the Minor N a t i o n ’s leaders, or successful int e rve n t i o n
+on behalf of the Minor Nation in a war st a rted by another Great Pow e r. Gre a t
+Powers cannot be taken over by these means. 
+In ra n d o m l y ge n e ra t ed w o rlds, t h e re are always seven Great Pow e rs and sixt e e n
+Minor Nations. These numbers may be different if you choose to play a scenario.IMPERIALISM: IMPERIALISM Basics 13
+CONTENTS
+Compound S team. A compound s team engine increases a vailable po wer and sa ves fuel by using the
+steam more than once.
+--- page 18 ---
+Control of Pr ovinces.
+A province is a political division of a Great Power or Minor Nation. All r a n d o m l y
+ge n e ra t ed w o rlds include 120 provinces. Each Great Power st a rts the game with
+eight provinces. Minor Nations have only f o u r. In scenarios, the number of
+p rovinces in the w o rld and the number within a single country can v a ry. Ev e ry
+province includes a capital city or a town.
+Military conflict happens at the pr ovince le vel. This means that each pr ovince has
+o n ly one owner at the end of a turn; provinces are fought over but may not be
+divided. Each province counts as one space for milit a ry units. If anyone inv a d e s
+the province, the regiments in the province defend it. 
+Conquests.
+C o n qu e r ed te rri to ry functions ex a c t ly like the t e rri to ry with which you st a rt th e
+game; you may develop the t e rrain, build ports and depots, and station troops in
+it. Re s o u r ces g a th e r ed at ports and depots in conq u e red te rri to ry appear in y o u r
+transport network. 
+All te rri to ry you conquer must be t a ken province by province. Although you can
+e l i m i n a t e a country by taking the province containing its capitol, the r e m a i n i n g
+te rri to ry of the country does not join you; instead it ent e rs into a st a te of anarchy.
+P rovinces in a st a te of anarchy produce no r e s o u r ces, and regiments st a t i o n e d
+th e re do not conduct att a c ks. Howev e r, these local f o rces defend t h e m s e l ves if t h e
+province is invaded. 
+No declaration of war is required to attack pr ovinces that are in a s tate of anar chy.
+If you eliminate ano ther country by taking its capitol, o ther Great P owers may see
+this as an opportunity to grab the remaining provinces without paying cos t ly
+declaration of war penalties.
+Colonies.
+When your Great Power gains a colony, the entire Minor Nation, including all its
+p rovinces, joins you at once. Howev e r, owning a Minor Nation colony is slightly
+d i ffe rent than owning conq u e red te rri to ry. Colonies retain a small amount of
+independence, and the owning Great Power must develop the r e s o u r ces of t h e
+c o l o n y by purchasing land from the colony. For more inf o rmation see t h e
+“Wo rking in Other Countries” section, st a rting on page 29. The r e s o u rc e s
+p roduced by colonies are traded on the w o rld market and not added to y o u r
+t ra n s p o r t net wo r k. As owner of the colony, your country enjoys a right of f i rst
+refusal on these resources.IMPERIALISM: IMPERIALISM Basics 14
+CONTENTS
+--- page 19 ---
+How to Win.
+A l though it might be possible to conquer the entire w o rld, your Em p i re would be
+u n b e a t able long bef o re the last enemy province fell. At a point when the w o rl d
+recognises that one Great Power has attained a dominant position, the winner is
+declared based on a vote by the world-wide Council of Governors .
+Council of Go vernors.
+A p p r ox i m a te l y eve ry ten y e a rs, each of the provinces in the w o rld brings one vote
+to the Council of Gov e rn o r s. Whenever a Great Power assembles the support of
+more than two-thirds of these provincial governors, that power wins the game.
+Nominations.
+The council f i rst nominates the two leading Pow e rs. Nominations r e flect t h e
+diplomatic, industrial, and military might of the Great P owers. Even if you possess
+the larg e st army among the Great Pow e rs, you may not r e c e i v e a nomination 
+if the council considers your economy under d eveloped, or you have become a
+diplomatic pariah. 
+Voting.
+Once two countries are selected as nominees for vict o ry, the provincial gov e rn o r s
+vote. If your Great Power is nominated you aut o m a t i c a l l y re c e i v e the suppor t i n g
+votes of the gov e rn o r s of provinces you own, whether as original t e rri to ry,
+c o n qu e r ed land, or colonial possessions. Although at the beginning of the g a m e
+m o st non-aligned gov e rn o r s abstain. As the game pr o gresses, the diplomatic,
+m i l i ta r y, and economic accomplishments of the successful Great Pow e rs cause an
+ever-increasing number of go vernors to of fer their support. Eventuall y, in the tent h
+council meeting, all go vernors must select one nominee or the o ther. At this point,
+if not earlier, one Great Power is declared the winner by a majority of votes. 
+How the Economy Wor ks.
+The success of the Great Pow e rs in I M P E R I A L I S M depends on the ability of t h e
+ru l e rs to ov e rcome short a ges and limited supply. You usually find y o u rself with
+i n s u f ficient money and insufficient commodities to do ev e ry thing you wish,
+especially at the beginning of the game.
+The Money Suppl y.
+E a ch Great Power begins the game with a limited amount of cash which is tot a l ly
+inadequate to meet its needs. There are three w ays to expand the cash a vailable t o
+your Great Power. 
+Fi rst, you must expand the trading might of your country. Ev e ry time you sell
+commodities to other countries you receive a cash payment for the sale.
+Second, gold and gems are not traded. Instead, these commodities provide a cash
+bonus to you whenever you transport them to industry. IMPERIALISM: IMPERIALISM Basics 15
+CONTENTS
+--- page 20 ---
+Third, you can receive profits from the activities of your De veloper unit and o ther
+civilian units in those Minor Nations where you have established embassies.
+It is dif ficult to be successful as an isolationist in IMPERIALISM . There is no income
+f rom t a xation; int e rnational commerce is the only way to build a subst a n t i a l
+treasury. 
+Classification and Value of Commodities.
+All commodities in the game are classified as resources, materials, or goods. 
+Resources.
+Re s o u r ces are commodities that are grown, such as liv e stock; or mined, such as
+coal. R e s o u r ces g e n e ra l l y are the most common and least valued commodities.
+The r e s o u r ces class includes: grain, liv e sto c k, fruit, fish, co t ton, wool, hor s e s ,
+timber, coal, iron ore, oil, gold, and gems.
+Materials.
+Materials are basic building blocks of production, created directly using a resource
+or re s o u r ces. Mat e rials usually have a mid-r a n ge value and are used to cons t ru c t
+m o st units, f a c to r ies, mills, and tr a n s p o r t capacity. Mat e rials are also used to
+p roduce goods. The mat e rials class includes canned food, f a b ric, paper, lumber,
+steel, and fuel.
+Goods.
+Goods are the highest level and most e x p e n s i v e of the commodities. Three of t h e
+four goods in IMPERIALISM , clothing, furniture, and hardware, are called consumer
+goods. Their chief usefulness is as items to sell to other countries to make money.
+Fu rn i t u r e and clothing also help you encour a ge migration to indus t ry. Un l i ke
+m a te r ials, consumer goods are not used to expand your economy or cons t ru c t
+units. The f o u rth type, armaments, can be sold like the consumer goods, and are
+required for the construction of military and naval units.IMPERIALISM: IMPERIALISM Basics 16
+--- page 21 ---
+Saved Games.
+IMPERIALISM provides eight save slots.
+Saving a Game.
+To save your game follow these steps:
+• From the Te rrain Map s c reen, click on the Game Contr o l s b u t ton 
+marked with a computer icon.
+• On the dialog box, click on the Save Game button. The Chart Room screen 
+appears.
+• T h e r e are eight c h a rts re p resenting your eight save slots. Click on one of the 
+charts.
+• Type a name for your game, which can be up to 31 characters long.
+• Click on the Save Game b u t ton, after your game saves, you aut o m a t i c a l l y 
+return to the Terrain Map screen.
+If you want to exit the Chart Room without saving, click on the Ladder at the lef t
+side of the screen.
+Loading a Sa ved Game.
+When you enter the C h a r t Ro o m to load a saved game, the aut o s ave is select e d .
+To load this game, sim p ly click on Load Game . To load other saved games f o l l ow
+these steps:
+From the IMPERIALISM Screen
+• Click on the Bottle
+• In the C h a r t Ro o m , click on the save slot you wish to load. The map of 
+this game appears on the right of the screen,
+• Click on the Load Game button
+From the Ter rain Map Screen
+• Click on the Game Controls button marked with a computer icon.
+• On the Game Contr o l smenu, click on the Load Game b u t ton. The C h a r t Ro o m
+screen appears.
+• In the C h a r t Ro o m click on the save slot you wish to load. The map of this 
+game appears on the right of the screen,
+• Click on Load Game button.
+More Than Eight Sa ves.
+If you want to keep more than eight saved games, go to your I M P E R I A L I S M s ave d
+games folder bef o re you st a rt the game and move the old saves into a separ a te
+fo l d e r . No rmal saves are labelled as SLOT “X”.IMP, where the “x” r e p resents a
+number 0-7. The autosa ve is labelled SL OTA .IMP, and all your multipla yer sa ved
+games are labelled MULT “X”.IMP. Once you move your old saves out of t h e
+IM P E R I A L I S M s aved games folder t h ey no longer appear in the C h a r t Ro o m a n d
+new saves can be placed in those slots.IMPERIALISM: IMPERIALISM Basics 17
+CONTENTS
+--- page 22 ---
+WHAT HAPPENS ON THE TERRAIN MAP
+The Te rrain Map s c reen provides you with a central command centre f o r
+managing your growing Em p i re. From this screen you access the Game Contr o l
+dialog, and click the End Tur nbutton. Although you make decisions each turn using
+a va ri ety of screens and dialogs, you always re t u rn to the Te rrain Map s c re e n
+before advancing to a new turn.
+Establishing a Capital City .
+If you play on the N o rm a l , H a rd, or N i g h - O n - I m p o s s i b l e s ettings, you build your o w n
+c a p i t al city upon st a rting a new game. The capital must be cons t ru c t ed on f l a t
+te rrain with access to w a te r. Your Minister w a rns you if you try to build on an
+i l l e gal tile. While choosing a site f o r, and cons t ructing, your capital city, scr o l l i n g
+is limited to spaces over your own country.
+When a tile is selected for your capital city, a dialog which sa ys: Local food can sustain
+nhealthy population ( xm a x i m u m ) . The higher the number of population your capit a l
+can support the be t te r. See the “Food Consumption” section, st a rting on page 55
+for more information.
+G e n e ra l l y, you should search for a tile near plentiful food with access to timber,
+wool, or co t ton to assist your early development. Capitals built on a r i ver in a
+province with no coastline are much safer from seaborne invasions.
+The Map.
+The map provides a view of the entire w o rld. You scroll by moving the mouse
+c u rsor to the edge of the screen. Holding down the C o n t ro l key and clicking on
+the map centres the screen where you clicked. On r a n d o m l y cre a ted w o rlds y o u
+m ay scroll around the w o rld to the east or w e st, but you are blocked in the Ar c t i c
+and Ant a rctic regions. For most scenarios, the w o rld is r e c ta n g u l a r ; you cannot
+scroll off the map edge.IMPERIALISM: What Happens on the Ter rain Map 18
+CONTENTS
+Help & Information
+Mini MapGame Controls Current T reasur yEye cursor identifies
+where to prospect
+Orders Buttons
+Unit Buttons
+End Tur nSelected Prospector
+in Toolbar
+Selected Prospector on Map
+--- page 23 ---
+Borders.
+Countries are divided from each o ther either by sea, or by a wide, coloured border
+if two countries appear on the same land mass. These bor d e rs include the colour
+of each country on that country’s side of the border.
+W h i t e lines be t ween fr i e n d l y provinces r e p resent provincial bor d e rs. Bor d e rs in
+the sea divide the sea zones from each other.
+Terrain Tiles.
+Although for military units a pr ovince is considered one space, for the purposes of
+building and development, which are the realms of civilian units, a province is
+divided into t e rrain tiles. Each t e rrain tile is a space for a civilian unit to w o rk in.
+E n g i n e e r s and Dev e l o p e r s, with the necessary t e ch n o l o g y , may w o rk in most
+terrain tiles. Other civilian workers function only in certain types of terrain tiles.
+I n fo–click on any t e rrain tile to find out what is in that tile. Note that the only
+types of t e rrain that cannot be im p roved by a civilian w o rker are the dry plains,
+the horse r a n ch, and the scrub f o re st. If a r i ver is present in any tile, that t e rra i n
+tile can produce fish in addition to the commodities listed below.
+Terrain Tiles Table.
+Terrain Tile. Civilian Workers. Possible Resources.
+Dry Plains . . . . . . . . . . . . . . . . . . . None . . . . . . . . . . . . . . . . . . . . . . . . . . Grain
+Open Range . . . . . . . . . . . . . . . . . Rancher  . . . . . . . . . . . . . . . . . . . . . . . Livestock
+Horse Ranch . . . . . . . . . . . . . . . . . None . . . . . . . . . . . . . . . . . . . . . . . . . . Horses
+Plantation . . . . . . . . . . . . . . . . . . . Farmer  . . . . . . . . . . . . . . . . . . . . . . . . Cotton
+Farm. . . . . . . . . . . . . . . . . . . . . . . . Farmer  . . . . . . . . . . . . . . . . . . . . . . . . Grain
+Orchard . . . . . . . . . . . . . . . . . . . . . Farmer  . . . . . . . . . . . . . . . . . . . . . . . . Fruit
+Fertile Hills . . . . . . . . . . . . . . . . . . Rancher  . . . . . . . . . . . . . . . . . . . . . . . Wool
+Barren Hills . . . . . . . . . . . . . . . . . . Miner, Prospector  . . . . . . . . . . . . . . . Iron or Coal
+Mountains . . . . . . . . . . . . . . . . . . . Miner, Prospector  . . . . . . . . . . . . . . . Iron, Coal, Gold, Gems
+Hardwood Forest. . . . . . . . . . . . . . Forester . . . . . . . . . . . . . . . . . . . . . . . . Timber
+Scrub Forest. . . . . . . . . . . . . . . . . . None . . . . . . . . . . . . . . . . . . . . . . . . . . Timber
+Swamp . . . . . . . . . . . . . . . . . . . . . . Driller, Prospector  . . . . . . . . . . . . . . . Oil
+Desert. . . . . . . . . . . . . . . . . . . . . . . Driller, Prospector  . . . . . . . . . . . . . . . Oil
+Tundra . . . . . . . . . . . . . . . . . . . . . . Driller, Prospector  . . . . . . . . . . . . . . . Oil
+Not e :P ro s p e c to r s must find minerals or oil bef o re the Miner or Oil Driller units
+can be used to extract them.
+Towns.
+E a ch province contains one town, unless the capital of the country is
+l o c a t ed th e re instead. Towns supply no r e s o u r ces at the beginning of
+the game. Only the Engineer can work in the t own. Later, t owns begin
+to produce industrial commodities like steel or lumber.IMPERIALISM: What Happens on the Ter rain Map 19
+CONTENTS
+--- page 24 ---
+Capital Cities.
+C a p i t als produce r e s o u r ces depending on their location; for inst a n c e ,
+if set in the f o re st, a capital produces timber. Only the Engineer may
+wo rk on a capital t e rrain tile, but since the capital tile aut o m a t i c a l l y
+p roduce r e s o u r ces at the highest possible level (depending on
+technology), the other civilian units are not needed there. 
+Rivers and Coasts.
+R i ve r s wind from mountain t e rrain tiles to the sea coast, passing t h rough ot h e r
+te rrain along the way. W i th two ex c e ptions, a tile with a r i ver is identical to a tile
+w i thout one. The f i rst ex c e ption is that an Engineer may cons t ruct a port on a
+ri ver tile, the second ex c e ption is that r i ve rs, like coasts, produce one unit of f i s h
+per turn for adjacent ports.
+Sea Zones.
+The w o rl d ’ s oceans are divided into Sea Zones just as the land is divided into
+p rovinces. In most respects, sea zones function for naval conflict in the same way
+that provinces w o rk for land battles. Howev e r, the sea is a big place, and it is
+possible for more than one f l e et, even hostile f l e ets, to occupy the same sea zone at
+the same time. This means that sea zones do not have an owner as provinces do,
+a l though a f l e et in undisputed occupation of a zone controls that sea zone for some
+game purposes such as cutting off ports from the tr a n s p o r t net wo r k. For more
+i n fo r mation see the “How Connections Are Lost” section, st a rting on page 45.
+Terrain Map Screen Toolbar .
+The buttons of the toolbar c h a n g e slightly depending on the type of unit (na v y,
+a rmy, or civilian) curr e n t ly selected. The buttons which are used to give or d e rs to
+units and the central display area on the toolbar are discussed in the “T oolbar f o r
+C i v i l i a n s , ” “Toolbar for R e g i m e n t s , ” and “Toolbar for Fleets” sections on pag e s
+24, 36, and 40, respectivel y. The rest of the buttons supply game functions and ar e
+always available on this screen. 
+The Top Buttons.
+At the top of the toolbar you see four buttons: Z o o m , Invest in T e c h n o l o g y , G a m e
+Controls , and Helpbutton .
+The Zoom Button.
+The Z o o m b u t ton, which appears as a magnifying glass, controls the zoom
+l evel of the t e rrain map. The default view is nor m a l l y best, but when you 
+a re moving f l e ets or civilian units long distances, it can be useful to zoom out. 
+The In vest in Technology Button.
+The Invest in Technology button, which appears as a microscope, takes you t o
+the t e chnology inv e stment screen. This button appears lighter than t h e
+surrounding wood when there is a new technology to invest in.IMPERIALISM: What Happens on the Ter rain Map 20
+CONTENTS
+--- page 25 ---
+The Game Controls Button.
+The Game Contr o l sb u t ton appears as a com p u te r . Click here to bring up
+the Game Controls dialog which allo ws you to sa ve, load, quit, and s tart a
+n ew game. You should g e n e ra l l y save ev e ry fi ve or six turns. This dialog
+also allows you to access the P re f e re n c e s s c reen where you can c h a n g e th e
+settings for Minister Briefings, Warnings and so on.
+The Help Button.
+The H e l p b u t ton is available on the Te rrain Map s c reen and on many of
+the other screens in the game, including all four O rd e r ss c reens. Clicking
+on this button accesses the Help and Inf o rm a t i o n dialog. For more
+i n fo r mation see the “Help and Inf o rmation Dialog” section, st a rting on
+page 9.
+Mini–Map.
+When you look at a Mini-Map, you see in miniature appro x i m a te l y one-q u a rte r
+of the w o rld. The Mini-Map shows political and milit a ry control over t h e
+continents, but does not show any t e rrain. It provides the easiest method f o r
+m oving v a st distances. Click on the Mini-Map to jump to a new location on t h e
+Terrain Map .
+The End Turn Button.
+The End Tur nbutton appears only on the Terrain Map screen at the bottom of the
+to o l b a r . When you click here, you are committed. No or d e rs can be cancelled or
+changed once you end your turn. 
+The Cycle of Units.
+The Te rrain Map s c reen provides a method for commanding all your units:
+civilian, milit a ry, and naval. Available units are selected for you one by one and
+s h own both on the map and in the t o o l b a r . As each unit appears, you have t h e
+opportunity to give it new orders. This process is called the units cycle.
+The selected unit (or units in the case of f l e ets and g a rrisons) has a flashing white
+outline on the Te rrain Map . In the toolbar you see a picture of the unit or units
+you could curr e n t ly command. On the map, army units are grouped into
+ga rrisons, naval units are grouped into f l e ets. When a g a rrison or f l e et is select e d ,
+the toolbar br e a ks down the g a rrison or f l e et into its component parts, sho w i n g
+the individual units in the group.
+As the units cycle each turn, you may give or d e rs using the toolbar buttons or by
+clicking dir e c t ly on the map. Units that r e c e i v e ord e rs that t a ke more than one
+t u rn to finish do not appear in the cycle while t h ey are still w o rking. Of cour s e ,
+you can seek them out, observe their actions, and, if you wish, cancel or c h a n g e
+their orders. When a unit finishes its job, it returns to the cycle automatically.IMPERIALISM: What Happens on the Ter rain Map 21
+CONTENTS
+--- page 26 ---
+Map Cursors.
+A va ri ety of cur s o rs assist you in commanding your units, obtaining inf o rm a t i o n ,
+and selecting units.
+Command Cursors.
+Command cur s o rs are used when a unit, g a rrison, or f l e et is already selected. As
+you move your mouse across the t e rrain map, the cursor c h a n g es to inf o rm yo u
+what command you would give to the selected unit by clicking on the spot under
+the cursor. If you click on a spot accidentally and give a unit the wrong command,
+you can cancel the order using the informational blue question mark cursor.
+Command Cursors Table.
+Cursors. Units Commanded. Function of Cursor.
+All Civilians except                            Engineer constructs, all 
+ . . . . . . . . . . . . . . . . . . . . . Prospector and Developer   . . . . . . . . others improve production of resources
+ . . . . . . . . . . . . . . . . . . . . . Engineer   . . . . . . . . . . . . . . . . . . . . . Build rail into tile
+ . . . . . . . . . . . . . . . . . . . . . Prospector  . . . . . . . . . . . . . . . . . . . . Search for minerals or oil in tile
+ . . . . . . . . . . . . . . . . . . . . . Developer   . . . . . . . . . . . . . . . . . . . . Buy the tile for future development
+ . . . . . . . . . . . . . . . . . . . . . All Civilians  . . . . . . . . . . . . . . . . . . . Deploy to tile, no work this turn
+ . . . . . . . . . . . . . . . . . . . . . Military Garrisons   . . . . . . . . . . . . . . Deploy to adjacent province
+ . . . . . . . . . . . . . . . . . . . . . Military Garrisons   . . . . . . . . . . . . . . Deploy to distant province
+ . . . . . . . . . . . . . . . . . . . . . Military Garrisons   . . . . . . . . . . . . . . Attack adjacent province
+ . . . . . . . . . . . . . . . . . . . . . Fleets   . . . . . . . . . . . . . . . . . . . . . . . . Move to new sea zone
+ . . . . . . . . . . . . . . . . . . . . . Fleets   . . . . . . . . . . . . . . . . . . . . . . . . Patrol in current sea zone
+ . . . . . . . . . . . . . . . . . . . . . Fleets   . . . . . . . . . . . . . . . . . . . . . . . . Blockade port in sea zone
+ . . . . . . . . . . . . . . . . . . . . . Fleets   . . . . . . . . . . . . . . . . . . . . . . . . Move into a friendly port.
+Establish a site for a landing on coast 
+ . . . . . . . . . . . . . . . . . . . . . Fleets   . . . . . . . . . . . . . . . . . . . . . . . . of this sea zoneIMPERIALISM: What Happens on the Ter rain Map 22
+CONTENTS
+--- page 27 ---
+Selection Cursors.
+These cur s o rs are used to select a new unit — either when another unit is alr e a d y
+selected or when no unit is selected. By clicking on the unit indicated by the cursor ,
+you select that unit indicated by a flashing white outline. Since t h e re is an
+automatic unit cycle, selecting each of your a vailable units in turn, you need to use
+these selection cursors only when you want to command units in a dif ferent order ,
+or when you have previously removed a unit from the cycle.
+Selection Cursors Table.
+Cursors. Units Commanded. Function of Cursor.
+.......................... All civilian units  .................................... Select the civilian indicated
+.......................... All military land units ............................ Select the garrison indicated
+.......................... All fleets  ................................................ Select the fleet indicated
+Information Cursors.
+Not sur p ri s i n g ly, these cur s o rs provide inf o rmation. The blue q u e stion mark
+cursor also allows you to cancel the orders once you see what they are.
+Information Cursors Table.
+Cursors. Units Commanded. Function of Cursor.
+The selected units cannot move
+ . . . . . . . . . . . . . All your units  . . . . . . . . . . . . . . . . . . . . . . . . to, deploy to, or work in that location 
+Click on the indicated unit to 
+obtain information, or cancel existing orders
+ . . . . . . . . . . . . . All your units  . . . . . . . . . . . . . . . . . . . . . . . . (a blue question mark)
+Click on the enemy area to receive
+ . . . . . . . . . . . . . Adjacent enemy units or provinces  . . . . . . . a scouting report (a red question mark)
+Civilian Units.
+Civilian units develop and im p rove land on the Te rrain Map s c reen. None of t h e
+civilians have any ability to attack or even defend t h e m s e l ves. If present in a
+province when the province is lost, the civilian is automatically killed. 
+All civilians, with the ex c e ption of the Dev e l o p e r , are cons t ru c t ed using an e x p e r t
+wo rke r, paper, and cash on the I n d u st r ys c reen in the U n i ve rs i t y . Once or d e re d
+in the University, civilians appear on the Terrain Map at the s tart of the next turn.
+For instructions on how to construct civilians see the “University” section, s tarting
+on page 55. IMPERIALISM: What Happens on the Ter rain Map 23
+CONTENTS
+--- page 28 ---
+All civilians may move any distance each turn. Howev e r, th ey cannot enter land
+controlled by o ther Great P owers; nor can they deploy to Minor Nations until you
+e stablish an Embassy t h e re. They can always deploy to land you own by right of
+conquest or colonisation.
+Toolbar for Civilians.
+For the most part you command your civilians on the t e rrain map using the 
+map cur s o rs. Howev e r, four toolbar buttons can be used whenever a civilian is
+s e l e c t ed. These buttons appear dir e c t ly above the picture of the selected civilian
+unit on the toolbar.
+The Disband Command.
+The f i rst button on the left provides the option of disbanding the select e d
+civilian and sending him back to industr y. Each civilian unit costs you one
+ex p e r t indus t rial w o rker when built in the U n i ve rs i t y , so disbanding him
+ret u rns him to indus t ry and gives you four more labour per turn for indus t ry. Yo u
+do not r e c over the cost of cash and paper or i g i n a l l y spent to make the e x p e r t into
+a civilian w o rke r. When you click this button you must conf i rm that you want to
+disband the unit. Unlike most orders, you cannot take this order back.
+The N ext Unit Command.
+The second button, which appears as a small arrow pointing to the r i g h t
+side of the screen, advances you from the curr e n t ly selected unit to t h e
+n ext unit in your cycle. This w o rks for f l e ets and g a rrisons as well as f o r
+civilian units. Use this button when you want to delay giving or d e rs to this unit
+until later in the turn.
+The Done Command.
+The D o n e b u t ton, t h i rd in the row on the t o o l b a r , appears as a small X.
+This command, if given to a selected unit, tells the unit to do nothing f o r
+this turn only. The unit appears normally in the cycle next turn.
+You might use this button when a civilian t e mp o ra ri l y has nothing to do, or when
+you lack the cash to pay for the civilian’s im p rovements. Next turn, if
+circumstances change, you can order the civilian at that time.
+The Sleep Command.
+LikeDone, the Sleep command ends the unit ’s turn. Ho wever, ordering the
+civilian to sleep r e m oves it from the cycle of units for future turns as w e l l .
+You might decide to give this order when a civilian has no thing to do for a
+long time, but you expect to want him later.
+Once the unit is sleeping, you must use the selection cursor to r e sto re the sleeping
+unit to the cycle. Since you still see the sleeping unit on the T e rrain Map, it’s not
+difficult to find him and click on him with this cursor. You can also use the Wake all
+U n i t s key b o a r d shortcut, by pressing the  “ w ” key, to w a ke up all sleeping units
+and return them to the cycle. IMPERIALISM: What Happens on the Ter rain Map 24
+--- page 29 ---
+Work of Civilian Units.
+All civilian units are used to develop the commodities available in t e rrain tiles.
+Their functions include: finding commodities (Pr o s p e c t or), im p roving pr o d u c t i o n
+l evels of commodities (F a rm e r , Miner, R a n ch e r , Fo re ste r, Driller), connecting
+commodities to the tr a n s p o r t net wo r k (Engineer), and buying land in ot h e r
+countries so the land can be developed (Developer).
+The f o l l owing table shows how many units of a commodity can be e x t ra c t ed fr o m
+one tile at each of four possible levels of development, with level 0 meaning t h e
+l evel a tile st a rts at bef o re a civilian has im p roved it. The table also shows which
+type of civilian unit improves the development level for that commodity.
+Resource Development Table.
+Resources Improve Production with Level 0 Level 1 Level 2 Level 3
+Grain  . . . . . . Farmer  . . . . . . . . . . . . . . . . . . . . . . . . . 1  . . . . . . . . 2  . . . . . . . . 3 . . . . . . . . 4
+Fruit  . . . . . . . Farmer  . . . . . . . . . . . . . . . . . . . . . . . . . 1  . . . . . . . . 2  . . . . . . . . 3 . . . . . . . . 4
+Livestock  . . . Rancher  . . . . . . . . . . . . . . . . . . . . . . . . 1  . . . . . . . . 2  . . . . . . . . 3 . . . . . . . . 4
+Fish  . . . . . . . None  . . . . . . . . . . . . . . . . . . . . . . . . . . . 1  . . . . . . . . None  . . . . . None . . . None
+Cotton  . . . . . Farmer  . . . . . . . . . . . . . . . . . . . . . . . . . 1  . . . . . . . . 2  . . . . . . . . 3 . . . . . . . . 4
+Wool . . . . . . . Rancher  . . . . . . . . . . . . . . . . . . . . . . . . 1  . . . . . . . . 2  . . . . . . . . 3 . . . . . . . . 4
+Timber . . . . . Forester  . . . . . . . . . . . . . . . . . . . . . . . . . 1  . . . . . . . . 2  . . . . . . . . 3. . . . . . . . 4
+Coal  . . . . . . . Miner  . . . . . . . . . . . . . . . . . . . . . . . . . . 0  . . . . . . . . 2  . . . . . . . . 4 . . . . . . . . 6
+Iron  . . . . . . . Miner  . . . . . . . . . . . . . . . . . . . . . . . . . . 0  . . . . . . . . 2  . . . . . . . . 4 . . . . . . . . 6
+Gold . . . . . . . Miner  . . . . . . . . . . . . . . . . . . . . . . . . . . 0  . . . . . . . . 1  . . . . . . . . 2 . . . . . . . . 3
+Gems  . . . . . . Miner  . . . . . . . . . . . . . . . . . . . . . . . . . . 0  . . . . . . . . 1  . . . . . . . . 2. . . . . . . . 3
+Oil  . . . . . . . . Driller  . . . . . . . . . . . . . . . . . . . . . . . . . . 0  . . . . . . . . 2  . . . . . . . . 4 . . . . . . . . 6IMPERIALISM: What Happens on the Ter rain Map 25
+CONTENTS
+--- page 30 ---
+Prospector .
+M o st re s o u r ces on the T e rrain Map are aut o m a t i c a l l y revealed to you just
+by looking at the type of t e rrain tile. For instance, you know that co t ton is
+p resent at ev e ry cot ton plantation t e rrain tile. You need not search for it.
+H oweve r, coal, iron, gold, gems, and oil must be found by a Pr o s p e c to r
+before they can be exploited by your other civilians. 
+Wi th a Pr o s p e c t or selected, an eye cursor lets you know if the tile under y o u r
+c u rsor is eligible for the selected Pr o s p e c t or to search. Since the four minerals are
+found only in barren hill and mountain tiles, the eye appears only over those tiles
+at the beginning of the game. Lat e r, when your country inv e sts in Oil Dr i l l i n g
+technology, the e ye cursor appears o ver unprospected swamps, deserts, and tundr a
+as well. If a Pr o s p e c t or of your Great Power has already searched a tile, you see a
+small pickaxe and a red “X” when the Prospector is selected. 
+On the t o o l b a r , small t e rrain tiles under the inf o rmation about a select e d
+P ro s p e c t or let you know how many t e rrain tiles are left to search in the country t h e
+P ro s p e c t or is in. To find these remaining t e rrain tiles q u i c k l y, click on the small tiles
+in the t o o l b a r , and the screen moves immediat e ly to the next un p ro s p e c t ed tile. 
+Engineer .
+The Engineer is the only civilian with multiple functions. His most
+i mp o r tant duty is the cons t ruction of a tr a n s p o r t net wo r k that joins y o u r
+i n d u st r y to the r e s o u r ces developed by all of your other civilian units on
+the T e rrain Map. He can also increase the def e n s i v e capabilities of a
+province by building forts.
+When the Engineer is selected, two working cursors are a vailable. With the cursor
+over tiles adjacent to the Engineer’s current location you see a small piece of
+railroad track. Clicking on one of these adjacent tiles orders the Engineer to spend
+the turn building a r a i l road line be t ween his present tile and the tile you click e d
+on. Howev e r, you do not always have the t e chnology necessary to build rail into
+certain terrain.
+When you click on the tile where the Engineer is located, you see the ot h e r
+wo rking cur s o r, a hammer. This or d e rs the Engineer to cons t ruct something in
+that tile. A pop-up dialog lets you select the type of cons t ruction. Choices f o r
+c o n st r uction include rail depots, ports, and f o rt i fications. Howev e r, some of t h e s e
+m ay not be available in certain t e rrain tiles. More advanced cons t ru c t i o n
+te chnology increases the number of types t e rrain where rails may be laid and
+d e p o ts may be built. P o rts always r e qu i r e access to w a te r. Fo rt i f ications are built
+throughout the province, not just the current tile.IMPERIALISM: What Happens on the Ter rain Map 26
+--- page 31 ---
+Miner .
+M i n e r s cannot be used until a Pr o s p e c t or locates some gold, gems, coal,
+or iron to mine. Once you have discov e red a mineral deposit and t h e
+Miner is selected, you see a hammer cursor over the tile with unmined
+m i n e r als. Clicking on that tile commands the Miner to w o rk th e re ,
+opening a mine. Until a mine is built, the tile does not produce minerals. U n l e s s
+your new mine is next to your capital, you must make sure that the mine is on or
+w i thin one tile of a connected port or rail depot. Ot h e rwise, the mined r e s o u rc e s
+are not reflected in your transport network. 
+When a Miner finishes opening a new mine it produces at Level I. Lat e r,
+once you ha ve invested in the technology for Square Set Timbering , your
+Miner can re t u rn to this Level I mine and im p rove it to Level II.
+E ve n t u a l l y, the t e chnology for D y n a m i t e m a kes Level III mining possible. Gold
+and gems produce at the r a te of one unit per level of the mine. Coal and ir o n
+mines produce at double this amount; so maximum coal or iron production is six
+units per turn from a Level III mine.
+Since all minerals are found in barren hills and mountains, these are the only
+terrain tiles where Miners can work.
+Farmer .
+Fa rm e r s imp rove the output of f a rms, orc h a rds, and plantations. Ev e n
+though dry plains do produce a f a rm product, grain, these tiles cannot be
+i mp r oved. When a F a rmer is selected, you see a hammer cursor over all
+tiles where im p rovements are possible with your present t e ch n o l o g i e s .
+Clicking on a tile commands the F a rmer to w o rk imp roving the gro w th of co t to n ,
+grain, or fruit in that tile. Unless this impr oved tile is next to your capital you mus t
+m a ke sure that the tile is on or within one tile of a connected port or rail depo t .
+Otherwise, the farmed resources are not reflected in your transport network. 
+Un l i ke minerals, f a rmed r e s o u r ces produce one unit per turn at Level 0 (wit h o u t
+a ny im p rovement by a F a rmer). The f i rst im p rovements made by a F a rmer r a i s e
+p roduction to Level I (two units per turn). Lat e r, Level II and Level III become
+possible with the in vestment in new technology. At the beginning of the game, the
+fa rms and orc h a rds adjacent to your capital city are aut o m a t i c a l l y im p roved to
+Level I, even before you build a farmer in the University.
+Rancher .
+Ra n ch e r s imp rove the output of liv e stock r a n ches on the plains, and t h e
+growing of sheep in f e rtile hills. At the beginning of the game, y o u r
+Un i ve r sity cannot build a R a n cher unit. R a n ch e r s are not available until
+you invest in the technology of Feed Grasses .
+When a R a n cher is selected, you see a hammer cursor over all tiles where
+i mp r ovements are possible. Clicking on a tile commands the R a n cher to w o rk
+i mp r oving the gro w th of wool or liv e stock in that tile. Unless this im p roved tile is
+n ext to your capital you must make sure the tile is on or within one tile of a
+c o n n e c t ed port or rail depot. Ot h e rwise, the r e s o u r ces are not r e fl e c t ed in y o u r
+transport network.IMPERIALISM: What Happens on the Ter rain Map 27
+--- page 32 ---
+L i ve s tock and wool are produced at Level 0 (one unit per turn) wit h o u t
+a ny im p rovement by a R a n ch e r . The f i rst im p rovements made by a
+Ra n cher raise production to Level I (two units per turn). Lat e r, Level II
+and Level III become possible with the investment in new technology. 
+Forester.
+Fo re ste rs imp rove the output of timber in the har d wood f o re sts. Ev e n
+though scrub forests do produce a minimal amount of timber, their output
+cannot be impr oved. At the beginning of the game, your University canno t
+build a Fores ter unit. He is not a vailable until you in vest in the technology
+of Iron Railroad Bridges .
+When a F o re ster is selected, you see a hammer cursor over all f o re st tiles where
+i mp r ovements are possible. Clicking on a tile commands the F o re ster to w o rk
+impr oving the output of timber in that tile. Unless this impr oved tile is next to your
+capital you must make sure that the tile is on or within one tile of a connected por t
+or rail depot. Otherwise, the resources are not reflected in your transport networ k.
+Timber is produced at Level 0 (one unit per turn) without any
+i mp r ovement by a F o re ste r. The f i rst im p rovements made by a F o re ste r
+raise production to Level I (two units per turn). Lat e r, Level II and Lev e l
+III become possible with the investment in new technology. 
+Driller .
+D ri l l e r s cannot be used until a Pr o s p e c t or locates some oil to drill. A
+P ro s p e c t or cannot look for oil until you inv e st in Oil Dr i l l i n g te ch n o l o g y .
+Once you have discov e red some oil and the Driller is selected, you see a
+hammer cursor over the tile with undrilled oil. Clicking on that tile
+commands the Driller to w o rk th e re imp roving oil output. Until a derrick is built,
+the oil is not produced. Unless your new oil der rick is next to your capital you mus t
+m a k e sure that it is on or within one tile of a connected port or rail depo t .
+Otherwise, the oil resources are not reflected in your transport network. 
+When a Driller finishes opening a new oil derrick it produces at Level I. Lat e r,
+once you have inv e sted in the t e chnology for C h e m i st r y, your Driller can re t u rn
+to this Level I derrick and im p rove it to Level II. Ev e n t u a l l y, the t e chnology f o r
+I n t e r nal Combus t i o n m a kes Level III derr i c ks possible. Oil production for each
+t u rn is calculated at double the level of the derr i c k, so that maximum pr o d u c t i o n
+of oil is six units per turn from a single derrick.
+Special Civilian Unit: De veloper .
+E a ch Great Power is eligible to r e c e i v e one Developer unit as a rew a rd .
+Un l i ke other civilians, Dev e l o p e r s cannot be built in the U n i ve rs i t y . No
+Great P ower can e ver possess more than one at a time. The De veloper is a
+rewa rd for your successful f o reign policy with the Minor Nations. Once
+you own a Dev e l o p e r , you can purchase t e rrain tiles in Minor Nations f o r
+development, thus providing your country with overseas profits.IMPERIALISM: What Happens on the Ter rain Map 28
+--- page 33 ---
+You r e c e i v e the Developer rew a rd when your diplomatic relations with at least
+one Minor Nation ha ve impr oved suf ficientl y. Generall y, this le vel is reached mos t
+qu i c k l y by establishing an Embassy in a Minor Nation, then signing a non-
+a g gression pact, and f i n a l l y conducting a good volume of trade with the Minor
+Nation for a f ew years. You can speed this process by g ranting bribes to the leader s
+of the Minor Nation. All of these diplomatic initiatives are made on the Diplomacy
+Screen. For more information see the “Diplomacy” section, starting on page 71.
+A Developer w o rks only abroad in Minor Nations. He cannot w o rk within y o u r
+own borders. 
+Working in Other Countries.
+Wo rk perf o rmed by your civilian units in Minor Nations increases the production of
+re s o u r ces by those nations. This has two results, both beneficial to your Great Pow e r. 
+Fi rst, this increased production increases the amount of that r e s o u r ce off e red in
+t rade each turn by the Minor Nation. Instead of w o n d e r ing if a Minor Nation is
+going to sell coal, for ex a mple, you are guar a n teed the coal you helped dev e l o p
+will be sold each turn. Although this e x t ra coal is off e red on the w o rld market to
+all countries, if you are the fav o u red trading partner of the Minor Nation, and if
+you remember to enter a trade bid on coal, your Great Power is guar a n teed t h e
+chance to purchase the coal ahead of the other Great Powers.
+The second benefit is potential ov e rseas pr o fits. N o rm a l l y, when a Minor N a t i o n
+sells its r e s o u r ces, the Minor Nation keeps all the money from the sale. Howev e r,
+when the r e s o u r ces have been made available on the w o rld market due to
+development by a Great P ower, that Great P ower shares in the profits for the sale,
+re ga r dless of who buys the r e s o u r ces. The Great Pow e r’s share increases (up to
+100%) as the relationship between the two countries improves.
+Checklist for Working Abroad
+• Establish an Embassy with at least one Minor Nation.
+• Send a Prospector to this nation to find valuable minerals.
+• Continue to improve relations with the Minor Nation and gain a Developer.
+• Send the Developer to the Minor Nation to purchase land with valuable coal, 
+iron, gold, gems, cotton, wool, and timber.
+• Once land is purchased, deploy other civilians, such as Miners, R a n ch e r s, and 
+Farmers, to increase the output of the land.
+• Bid on the Bid and Off e rss c reen for the r e s o u r ces you have developed, 
+or merely gain money when other Great Powers buy those products.
+• View the success of your overseas development in the Deal Book every turn.
+• Continue the process with additional Minor Nations.IMPERIALISM: What Happens on the Ter rain Map 29
+--- page 34 ---
+Example: Overseas Profits.
+Once you purchase a t e rrain tile containing a non-mineral r e s o u r ce, the r e s o u rc e
+is produced (at Level 0) and sold by the Minor Nation ev e ry turn. Once an
+i mp r ovement is built on the land, the amount produced and sold by the Minor
+Nation increases. If another Great Power buys these r e s o u r ces from the Minor
+Nation, you receive a percentage of the money paid. This cash appears at the end
+of the Deal Book s u m m a r y as Overseas Pr o f i t s. If you bid on the r e s o u r ce dur i n g
+trade and buy these commodities yourself, you still pay full price on the of fer shee t
+d u ring trade; but at the end of trade the ov e rseas pr o fits are re t u rned to you by
+the Minor Nation. Eventuall y, this could be a refund of the t otal amount you paid
+for the r e s o u r ces if your relations with the Minor Nation im p rove to the highest
+possible level.
+When you purchase land in a Minor Nation (prior to any development by
+civilians), the land produces at Level 0. For most r e s o u r ces, this is one unit per
+t u rn; an ex c e ption is minerals where Level 0 is zero production. Howev e r, coal
+and iron are produced somewhat dif ferently by Minor Nations: the Minor Nation
+m a n a g es to use pr i m i t i v e mining t e ch n i q ues to produce one unit per turn of coal
+or iron at Level 0 without opening a mine. Ther e fo re, your purchase of the land
+reduces the Minor N a t i o n ’s output of coal or iron because, after your purc h a s e ,
+you must open a mine to achieve any production at all.
+Establish Embassies.
+Wi th the ex c e ption of the Engineer, your civilians can perf o rm useful w o rk in
+Minor Nations. Since the Minor Nations cr e a te their own tr a n s p o r t net wo r ks ,
+th e re is no need for an Engineer. No civilians may go abroad until you est a b l i s h
+an Embassy in the Minor Nation. Once you ha ve an Embassy, civilians may enter
+and leave the Minor Nation fr e e ly. Often, it is best to send a Pr o s p e c t or fi rst to
+find the most valuable sites containing minerals. This is unnecessary if you decide
+to develop only the non-mineral assets of the Minor Nation such as co t ton or
+timber. For information on es tablishing Embassies see the “Diplomatic Overtures”
+section, starting on page 73. 
+Using the De veloper: S taking a Claim.
+Once you have decided which sorts of land and r e s o u r ces you wish to develop in
+other nations, it is time to use the De veloper. In order to gain extra resources from
+a Minor Nation, the Developer must buy each terrain tile individually. 
+Wi th your Developer selected, move the cursor over the land you want to buy.
+You see a money bag cur s o r. When you click on the f o re sts, fe rtile or barren hills,
+m o u n t ains, co t ton plantations, deserts, tundra, or sw a mps under the cur s o r, th e
+Developer dialog appears. This gives you the price the Minor Nation asks for that
+p a rcel of land and allows you to purchase it if you wish. You can buy land for t h e
+production of gold, gems, coal, iron, cotton, wool, and oil. De velopers cannot buy
+food production tiles in other countries.
+When the Developer has purchased the land, you see a small flag in your Gr e a t
+Powe r’s colour posted on the tile. No other Great Power can use this land once
+you post a flag. You may notice the purchase flags of other Great Pow e rs in t h e
+Minor Nation you hope to develop.IMPERIALISM: What Happens on the Ter rain Map 30
+--- page 35 ---
+Development of Land.
+Land purchased by a Developer st a rts producing for you (and the Minor N a t i o n )
+i m m e d i a te l y. This production is at Level 0 until you bring other civilians to t h e
+tile and impr ove output. For oil and minerals, Le vel 0 is zero units per turn, so you
+must bring your drillers and miners to the Minor Nation to gain the resources.
+The benefits from your Dev e l o p e r ’s purchases can be maximised only if you send
+other civilian units abroad as well. Your Miners, for instance, can w o rk on
+p u rchased mineral sites in ex a c t ly the same way t h ey do in your own lands. As
+n ew te chnology im p roves the potential output of mines, the Miner can im p rove
+your possessions abroad and at home.
+Competing for a Colon y.
+A l though the initial benefits of ov e rseas development are significant, your long-
+te rm goal must be to make the Minor Nations, whose r e s o u r ces you develop, into
+colonies of your Great Pow e r. Once a Minor Nation is colonised you control its
+d e fence f o rces and can deploy r e i n fo r cements from your homeland should t h e
+c o u n t r y be t h re a t ened. A d d i t i o n a l l y, a colon y ’s relationship to the homeland is
+a l ways considered to be at the highest level, giving you 100% of the pr o fits fr o m
+the sale of the developed r e s o u r ces. F i n a l l y, once colonised, the Minor N a t i o n ’s
+votes at the Council of Gov e rn o r s aut o m a t i c a l l y go to you if your Great Power is
+nominated for victory.
+Un fo rt u n a te l y, other Great Pow e rs may seek to colonise the same Minor N a t i o n
+you hope to gain. Colonies are won in two ways. 
+Fi rst, a large number of trade deals coupled with a judicious use of br i b e ry helps
+you convince the Minor Nation to accept your in v i tation to join your Em p i re. Fo r
+m o re on these methods see the “Effects of Diplomacy on Trade” section, st a rt i n g
+on page 63 and the “Joining the Empire” section, starting on page 76. 
+Second, when a Minor Nation is att a c ked and asks you to defend it ag a i n st th e
+a t tacking Great Pow e r, if you agree to int e rvene, the gr a teful Minor Nation joins
+your Em p i re. You gain immediate control over the defence f o rces of the Minor
+Nation. Of course, your declaration of war on another Great Power may not be
+we l l - re c e i v ed by the r e st of the w o rld. For more inf o rmation see the “Offer to
+Intervene in a Minor Nation” section, starting on page 81. 
+Eventual Conquest.
+Tiles “de veloped” by o ther Great P owers remain in a Minor Nation pr ovince that
+is conq u e red. The conq u e ro r , howev e r, now controls all the t e rri to ry in the land
+including the land once considered purchased by the other Great Powers.
+Since, prior to conquest, the Minor Nation ’s province could use local cheap labour
+to tra n s p o r t the commodities to the trading port t h ey had not built a tr a n s p o r t
+system. Once the pr ovince is conquered, economic changes begin, and it becomes
+n e c e s s a r y to cons t ruct r a i l roads, depots, and ports to move the r e s o u r ces into t h e
+transport network of the conquering power.IMPERIALISM: What Happens on the Ter rain Map 31
+--- page 36 ---
+Land Forces.
+Your land milit a ry fo rces consist of regiments. There are 27 diff e rent types of
+regiments in the game organised into t h ree eras. During the f i rst era of the g a m e ,
+a p p r ox i m a te l y 181 5 - 1845, you may cons t ruct only the f i rst nine regiment types.
+As you inv e st in new milit a ry te chnologies in the 1840s, old regiment types are
+gradually replaced by new ones in the same generic categories. For e xample, once
+a new type of Heavy Cav a l ry is available, you can no longer cons t ruct the older
+type of regiment. You may choose to upgrade the older regiments to the new one
+w i thin their cat e g o r y, or you may leave your vet e ran troops with inf e rior and
+outdated weapons. 
+Change occurs again in the 1 870s. Usually by 1 875 ne wer unit types are becoming
+available. Once again, you may choose to upgrade your earlier units to the new
+type of regiment within their category. 
+Regiment Categories.
+The nine regiment cat e g o r ies can be upgraded with diff e re n t
+te chnologies, but t h e re is a grouping of the available milit a ry
+te chnology in the 1840s and in the 1870s. By the end of each of
+these decades, all nine categories ha ve normally received their ne w
+type of unit. Of course, you must inv e st in the t e chnology to make
+the new regiment types available for cons t ruction. For more on
+u p grading milit a ry units see the “T e chnological A d vances” section, st a rting on
+page 88.  IMPERIALISM: What Happens on the Ter rain Map 32
+CONTENTS
+Help & Information
+Mini Map
+Orders Buttons
+Unit Buttons
+End Tur nSelected Gar rison
+in Toolbar
+Arrows in Toolbar for
+Unit Selection
+“Silhouettes” Indicat e
+Unit Types N ot Present
+Selected Gar rison on Map
+--- page 37 ---
+Regimental Upg rade Requirement Table.
+Category. First Era c. 1815-45. Second Era c.1845-80. Third Era c.1880-end.
+Militia Minutemen Militia Conscripts
+(none) Breechloading Rifle Machine Guns
+Light Infantry Skirmishers Sharpshooters Rangers 
+(none) Bessemer Converter Machine Guns
+Regular Infantry Regulars Rifle Infantry Modern Infantry
+(none) Breechloading Rifle Machine Guns
+Heavy Infantry Grenadiers Guards Machine-gunners
+(none) Breechloading Rifle Machine Guns
+Light Cavalry Hussars Scouts Mechanised 
+(none) Bessemer Converter Internal Combustion
+Heavy Cavalry Cuirassiers Carbine Cavalry Armour 
+(none) Breechloading Rifle Internal Combustion
+Light Artillery Horse Artillery Field Artillery Mobile Artillery
+(none) Rifled Guns Heavy Guns
+Heavy Artillery Artillery Siege Artillery Railroad Guns
+(none) Rifled Guns Heavy Guns
+Combat Engineers Sappers Engineers Saboteurs
+(none) Bessemer Converter Dynamite
+Militia.
+These local defence f o rces e x i st in all countries and in all provinces at t h e
+beginning of the game. As a province develops, additional militia cat e g o r y
+regiments are aut o m a t i c a l l y added to the local g a rrison. U n l i ke all of your ot h e r
+forces, militia category regiments cannot be ordered to lea ve their home pr ovince.
+They fight only when the province is invaded. 
+Militia is the only cat e g o r y of land regiments that are not cons t ru c t ed in 
+the ar m o u r y and do not r e qu i r e indus t rial w o rke rs to cr e a te. They also upgr a d e
+a u to m a t i c a l l y, at no cost to you, when the appr o p ri a t e new t e chnology is purc h a s e d .
+M i n u t emen, Militia, and Conscr i pts (the t h ree types of Militia) are the w e a ke s t
+units of their r e s p e c t i v e eras. They should remain in their entr e n ch m e n t s
+w h e n e ver possible. Their morale br e a ks ra ther easily and their f i re is nor m a l l y
+inaccurate.
+Light Infantr y.
+The t h ree types of Light Inf a n t ry (Skir m i s h e r s, Shar p s h o o te rs, and R a n ge r s) are
+adept at using ter rain for concealment and take reduced damage when fired upon.
+They mo ve more quickly through rough country than do o ther infantr y. They ar e
+best used to dr aw fire from entrenched defenders, giving heavier units a chance t o
+approach unmolested.IMPERIALISM: What Happens on the Ter rain Map 33
+CONTENTS
+--- page 38 ---
+Regular Infantr y.
+Regulars, Rifle Infantr y, and Modern Infantry are the foundation of most armies.
+E s p e c i a l l y useful on defence, Regular Inf a n t ry also pack enough f i re p o we r,
+e s p e c i a l l y in the later eras, to help out on the att a c k. If you cannot aff o rd ve ry
+m a n y pow e rful units, these regiments are the best com p romise be t ween e x p e n s e
+and power in each era.
+Heavy Infantr y.
+H e avy inf a n t ry (Gr e n a d i e r s, Guards, and Mac h i n e - g u n n e r s) are among the more
+ex p e n s i v e of the regiments. Howev e r, for def e n s i v e purposes these regiments are
+the best money can buy. Even on the att a c k, these highly trained troops can oft e n
+blast through entrenchments manned by weaker types of infantry.
+Light Ca valry.
+L i ke Light Inf a n t ry, Light Cav a l ry in the f i rst two eras (Hussars, Scouts) is best
+used to draw the f i re of entr e n ched hostile regiments so that the attack r e g i m e n t s
+can approach closely without taking as much fire from the defenders. Mechanised
+Fo rces, the t h i rd era regiments, possess significant f i re p o wer and may be used to
+fo l l ow the higher - p riced Armour units, exploiting any br e a ks the Armour cr e a te s
+in the enemy lines.
+Heavy Ca valry.
+Your Heavy Cav a l ry (Cuir a s s i e r s, Carbineers, and Armour) are the best att a c k
+pieces available, especially in the f i rst and t h i rd eras. These pieces are e x p e n s i v e
+and are not ideal for defence because they cannot entrench.
+Light Artiller y.
+Light Ar t i l l e r y of all t h ree eras is most useful on the att a c k. These regiments can
+m ove q u i c k l y into r a n ge and batter enemy f o rt i f ications and entr e n ch m e n t s .
+Un l i ke all heavy ar t i l l e r y, these more mobile units can both move and f i re in t h e
+same turn
+Heavy Artiller y.
+H e avy Ar t i l l e r y is useful on attack and defence, though its slow movement and
+poor initiative can be impediments when advancing ag a i n st your foes. Do not let
+enemy units get close to your artillery, as it can be destroyed quickly if fired on.
+Combat Engineers.
+Your Combat Engineers are able to move f o rwa rd and appr o a ch enemy positions
+at little risk to t h e m s e l ves using tunnels t h ey can cons t ruct. When the Combat
+Engineers reach enemy fortifications and entrenchments, they conduct a po werful
+a t tack ag a i n st the position which does not harm the enemy units but can damage
+or des t roy the def e n s i v e cons t ruction. Because f o rts are a big adv a n ta g e, th e s e
+units are necessary to attack w e l l - p re p a r ed foes. For details on how to use t h e s e
+units see the “Combat Engineering” section, starting on page 86. IMPERIALISM: What Happens on the Ter rain Map 34
+--- page 39 ---
+Generals.
+As a rew a rd for army expansion, you r e c e i v e one or more Generals. A General is
+m u c h be t ter at assessing enemy f o rces in adjacent provinces than other local
+c o m m a n d e r s. In addition, Generals contr i b u te their leadership abilities to t h e
+performances of the ar my in battle by af fecting the morale of units in combat. See
+the “Leaders and Morale” section, starting on page 86 for more information.
+Order Your Land Forces.
+When a land gar rison is selected, the encampment of the gar rison sho ws a flashing
+w h i t e outline. The units in this g a rrison appear in the toolbar display. The f i rst
+step, using the t o o l b a r , is to select the regiments you want. You are selecting units
+for movement or d e rs; it is not necessary to give regiments or d e rs to stay behind
+and defend. Unit(s) remaining at the end of the turn aut o m a t i c a l l y defend t h e
+province from attack.
+No rm a l l y, all the units in the g a rrison are selected for movement by default with
+the ex c e ption of Militia cat e g o r ies which cannot be moved. If you want only a
+p o rtion of your mobile regiments to leave the province, you can control which
+units are selected with the arrows in the toolbar next to each unit type. 
+When you give movement or d e rs, the units not included in your selection r e m a i n
+behind, along with any militia, to defend the province. The toolbar arrows do not
+permit you to select particular regiments of a single category.
+If you want to make a more specific selection of f o rces you can use the Garr i s o n
+B o o k . See the “Garrison Display Command” section st a rting on page 36. This is
+n e c e s s a r y, for instance, if you want a particular vet e ran regiment of Hea v y
+Cavalry, among several present in the garrison, to conduct an attack.
+Using the Map Cursors.
+Deployment.
+T h e r e are four diff e rent ways you can move your selected army on the map. The
+cursor sho ws the type of mo vement a click on a given pr ovince would order. If you
+want to move to an adjacent fr i e n d l y province, click on that province with t h e
+M a r c hing Soldier c u rs o r . If you want to move the selected army furt h e r, but s t i l l
+in fr i e n d l y te rri to ry, click with the Tra i nc u rsor which appears over the dist a n t
+f ri e n d l y province. Your total amount of tr a n s p o r t capacity limits the number of
+m i l i ta r y units you can move by train in one turn. You increase the number of
+m i l i ta r y units you can move by building more tr a n s p o r t capacity in the r a i lya rd
+on the Indus t ry screen. Moving regiments does not in itself use capacity alr e a d y
+assigned to tr a n s p o r t re s o u r ces. F i ve points of tr a n s p o r t capacity are needed to
+move each armaments point of a military unit. See the “Regiment Abilities” char t
+on page 87 for a listing of the Armaments points in each type of military unit.
+Attacks.
+To enter a province you do not own, you must f i rst declare war on the owner of
+the province. On subsequent turns, any adjacent units may att a c k. You cannot
+a t tack unless your f o rces are adjacent to the t a rget province. The attack is made
+by clicking on the target province with the Crossed Swords cursor.IMPERIALISM: What Happens on the Ter rain Map 35
+--- page 40 ---
+Landings.
+The most dang e rous movement is an attack across the w a te r. Superf i c i a l l y, th i s
+seems ex a c t ly like an attack on an adjacent province. Once your f l e ets establish a
+landing site, you select land f o rces and use the C rossed Sw o rd s a t tack cursor to
+o rder them to move dir e c t ly across the seas to the enemy province. Howev e r, on
+the turn that this movement is or d e red, your land f o rces are e x t re m e l y vulner a b l e
+to hostile f l e et inte rc e p tion. Any enemy f l e ets ent e ring or present in the sea zone
+w i th the landing site aut o m a t i c a l l y inte rc e p t and battle the landing f l e ets. If any of
+your ships are sunk, some of your land f o rces may be drowned. For more
+i n fo r mation on establishing a landing site see the “Naval Landings” section, st a rt i n g
+on page 39.
+Toolbar For Regiments.
+The Gar rison Display Command.
+The f i rst milit a ry command button, which appears as a flag, brings up a
+d etailed book on the selected g a rrison. You may also view this book by
+clicking with the Blue Question Mark c u rsor dir e c t ly on the g a rri s o n
+encampment.
+The G a rrison Book s h ows the st a te of the selected g a rrison, including the 
+names, the health, and the medals of each regiment. Notice that t h e re are sev e ra l
+Militia units listed, but that t h ey bear the legend D e f e n d i n g . Militia units are 
+only for local defence.
+By clicking on the picture of any other type of unit you may select or unselect it
+i n d i v i d u a l l y. As you select a unit its notation c h a n g es from D e f e n d i n g to Av a i l a b l e .
+The notation Av a i l a b l e means that the regiment can be or d e red to move or att a c k
+when you click on another province. Notice also that the toolbar numbers of
+selected units change as you select units on the Garrison Book screen.IMPERIALISM: What Happens on the Ter rain Map 36
+Close Book
+Regiment Name
+Selected Regiments
+in ColourNonselected Regiments
+in Gr ayStatus Bar
+--- page 41 ---
+You also use the G a rri s o n book to upgrade units when available. If any upgr a d e
+is possible, an arrow with a small soldier icon appears in the book near the unit.
+When upgraded, the picture of the unit c h a n g es, but the pos t u re and positioning
+of the unit remains the same.
+You may rename a unit using the Garrison book; click on the name to type in the
+regiment’s new name.
+The N ext Unit Command.
+The Next Unit b u t ton, which appears as a small arrow pointing to the r i g h t
+side of the screen, advances you from the curr e n t ly selected g a rrison to
+the next unit in your cycle. Use this button when you do not know what
+orders to give, but you want another opportunity later in the turn.
+The Done Command.
+The D o n e b u t ton, t h i rd in the row on the t o o l b a r , appears as a small X.
+This command, if given to a selected unit, tells the unit to do nothing f o r
+this turn onl y. The unit appears normally in the cycle next turn. You might
+use this button when you do not want to mo ve your gar rison, but you want to keep
+it in the unit cycle. 
+The Defend Command.
+L i ke D o n e , the D e f e n d command (a castle wall icon) ends the unit’s tur n .
+However, ordering the gar rison to defend remo ves it from the cycle of units
+for future turns as well. You might decide to give this order when you ha ve
+decided a given garrison is a permanent defence force.
+Once a g a rrison is defending, you must use the selection cursor or the Wake all Units
+key b o a r d shortcut, by pressing the “ w ” key, to r e sto re the regiments to the unit cy c l e .
+Experience.
+Regiments gain experience, which is mar ked by a string of medals on the gar rison
+book display and in the toolbar during tactical combat. Experience is earned by
+p a rticipating in combat. Gener a l ly, participation in t h ree vict o ries or f i ve def e a t s
+earns one medal for the regiment.
+E a ch medal earned im p roves the initiative and the f i re p o wer of the r e g i m e n t .
+I n i t i a t i v e of all units in an army controls the order in which battles are r e s o lve d ,
+while initiative of each individual regiment controls when that unit acts in t a c t i c a l
+combat. F i re p o wer is sim p ly an attack value, used for both tactical and s t ra te g i c
+combat resolution. A regiment which earns the maximum of four medals is
+roughly twice as powerful as a unit of the same type with no medals.IMPERIALISM: What Happens on the Ter rain Map 37
+--- page 42 ---
+Three Me thods of Combat.
+On the Pr e fe rences screen you can choose to r e s o lve land battles on a s t ra te g i c
+l evel or using tactical battlefields. Once the tactical pr e fe rence is set, you can
+choose to r e s o lve the tactical fights y o u rself or order your Defence Minister to do
+so. In games with multiple human play e rs, st ra tegic resolution gr e a t ly reduces t h e
+waiting time between turns.
+Strategic Resolution.
+Combat values on the table in the “Regiment Abilities and Com p a rison” section,
+found on page 86, are a good way to es t i m a t e st ra tegic resolution. You should
+assemble o verwhelming force if possible since you will be unable to take advantag e
+of battlefield skills to make up for lack of numbers.
+Tactical Battle.
+If you choose to r e s o lve your battles on the tactical battlefield, two methods are
+available. F i rst, you can conduct all the operations y o u rself. For details on how to
+do this, see the “Fighting Battles” section, st a rting on page 82.  Alt e rn a t i ve l y yo u
+can ins t ruct your Defence Minister to fight the battle for you; once the battle
+begins, click on his picture at the bottom of the tactical toolbar.
+Naval Units.
+Fleets are represented in two w ays on the map. A fleet on s tation at sea is portr ayed
+as a large ship with a w a ke and a bow wave. A f l e et at anchor appears as a ship
+with furled sails near the port tile where the fleet is based.
+Order Your Fleets.
+When a f l e et is selected the ship icon shows a flashing white outline. The ships in
+this f l e et appear in the toolbar display. The f i rst step, using the arrows in t h e
+toolbar, is to select the ships you want to command. You select ships for mo vement
+or mission orders. Mission orders are car ried out in the sea zone where the fleet is
+already located. Mo vement sends the fleet to a new location. Fleets cannot do bo th
+a mission and a mo ve in the same turn. The only e xception in volves intercepting a
+landing f o rce aimed at your beaches. A f l e et ord e red to move into a sea zone
+containing hostile landing fleets intercepts the landing.
+No rm a l l y, all the ships are selected by default. If you want only a portion of y o u r
+ships to perf o rm a mission or move, you can control which ships are selected with
+the arrows in the toolbar next to each ship type. IMPERIALISM: What Happens on the Ter rain Map 38
+CONTENTS
+--- page 43 ---
+When you give mo vement orders, the ships not contained in your selection remain
+behind. The toolbar ar rows do not permit you to select particular ships of a single
+c a te g o r y. If you want to make a more specific selection of f o rces, you can use t h e
+fleet book. For more information see the “Fleet Book Command” section, s tarting
+on page 40. This would be necessary, for instance, if you w a n ted a par t i c u l a r
+veteran battleship, among several present in the fleet, to conduct a mission.
+Using the Map Cursors.
+Once you have made a selection of ships using the toolbar or the f l e et book, use a
+map cursor to command it. The map cur s o rs allow you to assign your select e d
+fl e et in four diff e rent ways: movement to another sea zone plus t h ree kinds of
+missions. 
+Moving a Fleet.
+To move the f l e et, click on a new sea zone with the ship’s Wheel Cur s o r. This
+c u rsor does not appear in the f l e et’s current sea zone. If the new zone is out of r a n ge
+you see a red slashed circle cur s o r; you cannot move the f l e et that far in one turn. 
+Patrols and Bloc kades.
+In its present sea zone, a f l e et can patrol, att e mpting to int e rc e p t all hostile ships,
+by using the Telescope cursor. A fleet can blockade a designated port, using a ship
+with a red “X” cursor, by clicking near the port when that cursor appears. Bo th of
+these commands are used ag a i n st enemy f o rces. A blockade has gr e a ter chance of
+success than a mere patrol ag a i n st ships that enter or leave the selected port. A
+blockade does not seek o ther ships in the sea zone, ho wever, hostile patrolling fleets
+can intercept your ships on blockade. 
+B oth blockades and patrols can result in battle ag a i n st hostile w a rships, or in
+i n te rc e p tion of merchant ships. When merchants are int e rc e p ted, the int e rc e pt i n g
+forces can sink or capture the mer chant ships. Additionall y, it is possible to captur e
+the cargo being carried. These details are summarised in the battle r e p o r t at t h e
+end of the turn.
+Naval Landings.
+Near the coast you see a Cannon cursor. This allo ws the fleet to es tablish a site for
+a later landing of army f o rces. When you assign f l e ets to this mission, you are
+a c c e p ting the potential of automatic int e rc e p tions by enemies. Any enemy f l e et
+that ent e rs the sea zone or patrols in the sea zone can find and int e rc e p t yo u r
+forces. You must be prepared to defeat these attacks. 
+You cannot move land f o rces on the turn the landing site is established. Land
+fo rces can be moved to the selected enemy province on any subsequent turns, as
+long as you maintain the landing site by keeping ships in that sea zone.IMPERIALISM: What Happens on the Ter rain Map 39
+--- page 44 ---
+Toolbar For Fleets.
+The Fleet Book Command.
+The f i rst naval command button, which appears as a flag, brings up a
+detailed book on the selected fleet. You may also view this book by clicking
+with the blue question mark cursor directly on the picture of the fleet.
+The F l e et Book s h ows you the details of the selected f l e et; including the names,
+the health, and the medals of each ship. By clicking on the picture of a ship y o u
+m ay select or unselect it individually. Notice that on the t o o l b a r , the number of
+selected units changes as you select units.
+You may rename the ships using the F l e e t Book . Click on the name to edit t h e
+name text.
+The N ext Fleet Command.
+The second button, which appears as a small arrow pointing to the r i g h t
+side of the screen, advances you from the curr e n t ly selected f l e et to t h e
+next unit in your cycle. Use this button when you do not know what order s
+to give, but you want another opportunity later in the turn.
+The Done Command.
+The D o n e b u t ton, t h i rd in the row on the t o o l b a r , appears as a small “X”.
+This command, if given to a selected f l e et, tells the f l e et to remain in t h e
+same sea zone, trying to stay out of trouble for that turn.
+You might use this button when do not want to do an y thing with your f l e et th i s
+turn, but expect to have orders for it in the near future. 
+The Defend Command.
+L i ke D o n e , the D e f e n d command ends the f l e et’s turn. Howev e r, ord e ri n g
+the f l e et to defend r e m oves it from the cycle of units for future turns as
+well. You might decide to give this order when you have decided a giv e n
+fl e et is a permanent defence f o rce in a sea zone, but you do not want it to try to
+find enemy ships. Gener a l ly, this button should not be used for f l e ets. It is be t te r
+to patrol with a low level of aggression.
+Once a f l e et is defending, you must use the selection cursor or the Wake all Units
+keyboard shortcut, by pressing the “w” key, to restore the fleet to the unit cycle.
+Setting Agg ression Le vels.
+D i re c t l y above the ship pictures in the toolbar are t h ree buttons that enable
+you to establish the aggression level of a f l e et. The default button (in t h e
+middle) means that the f l e et atte mpts to eng a ge any enemy it encount e rs ,
+when the officer in c h a rge of your f l e et believes it to be inf e rior to his f o rc e .
+This decision is im p o rtant even if your ships are not looking for enemies on a
+p a t rol, because enemies may be looking for them. The commander of your f l e et
+must decide whe ther to accept battle or try to flee based on this agg ression setting.IMPERIALISM: What Happens on the Ter rain Map 40
+--- page 45 ---
+The o ther two settings dramatically increase or decrease agg ression. The high le vel
+means your commander eng a ges all comers if he believes t h e re is even a r e m ote
+chance of vict o ry. This setting is most useful for f o rces whose commander car e s
+more about dealing out damage to o thers than preserving his own fleet. The mos t
+cautious setting means that the fleet tries to a void battle unless the of ficer in char ge
+believes he has an overwhelming advantage.
+When deciding which le vel to set, remember that your of ficers can make er rors in
+their es t i m a t es about the size of enemy f o rces. When in doubt, you should
+ge n e ra l l y choose the more cautious setting, unless it is im p o rtant to defend a
+particular zone or damage enemy fleets.
+Warship S tatistics.
+Warship S tatistics Table.
+• FRP. . . . . . . . . . . . . . . Firepower establishes the strength of the ship’s attack.
+• RNG.   . . . . . . . . . . . . . In naval combat range is the most important ability of the your ships.
+A ship with greater range starts dealing out damage before its foes 
+are able to respond.
+• ARM. . . . . . . . . . . . . . Armour determines the ship’s resistance to damage.
+• HULL. . . . . . . . . . . . . The size of the ship determines how long it takes to sink it once the 
+armour is penetrated.
+• BATT MV .    . . . . . . . . Speed in battle. A fleet with the edge in speed can force the action or 
+flee from the fight. A ship with both greater speed and greater range 
+can often sink the enemy and take no damage itself. 
+•Speed.   . . . . . . . . . . . . . The number of sea zones that this type of ship can move through 
+during a turn.
+Ship Type. FRP. RNG. ARM. HULL. BATTMV. Speed.
+Frigate ............................... 3 . . . . . . . . . . 5 . . . . . . . . . 10  . . . . . . . . . 35  . . . . . . . . . 4  . . . . . . . . . . . . 3
+Ship-of-the-Line .............. 6 . . . . . . . . . . 6 . . . . . . . . . 20  . . . . . . . . . 65  . . . . . . . . . 3  . . . . . . . . . . . . 2
+Raider ............................... 3 . . . . . . . . . . 7 . . . . . . . . . 20  . . . . . . . . . 30  . . . . . . . . . 7  . . . . . . . . . . . . 5
+Ironclad ............................ 5 . . . . . . . . . . 8 . . . . . . . . . 55  . . . . . . . . . 50  . . . . . . . . . 5  . . . . . . . . . . . . 3
+Armoured Cruiser ........... 6 . . . . . . . . . . 9 . . . . . . . . . 50  . . . . . . . . . 40  . . . . . . . . . 8  . . . . . . . . . . . . 6
+Advanced Ironclad ...........10  . . . . . . . . . 10  . . . . . . . . 60  . . . . . . . . . 70  . . . . . . . . . 6  . . . . . . . . . . . . 4
+Battle Cruiser ...................18  . . . . . . . . . 13  . . . . . . . . 55  . . . . . . . . . 90  . . . . . . . . . 9  . . . . . . . . . . . . 6
+Dreadnoughts ..................20  . . . . . . . . . 13  . . . . . . . . 70  . . . . . . . . .115 . . . . . . . . . 7  . . . . . . . . . . . . 5IMPERIALISM: What Happens on the Ter rain Map 41
+CONTENTS
+--- page 46 ---
+Types of Warships.
+Wa rships are classed as either fa stships or b a t t l e ships. F a st ships (Fr i ga te s ,
+Ra i d e r s, Ar m o u r ed Cr u i s e r s, and Battlecr u i s e r s) are used pr i m a ri l y for escor t i n g ,
+i n te rc e p ting, and blockading. To control a sea zone and des t roy an enemy f l e et
+the b a t t l e ships (Ships-of-the-Line, Ironclads, A d vanced Ironclads, and
+Dreadnoughts) are superior.
+Frigates.
+Frigates, the fas test ship ear ly in the game, are cheap to build and good at scouting.
+E a rly in the game, t h ey are eff e c t i v e commerce r a i d e r s. Fri ga tes are not scr a p p e d
+until Armoured Cruisers enter the game, but they are not very useful once Raider s
+can be built instead.
+Ships-of-the-Line.
+S h i p s - o f - t he-Line remain com p et i t i v e until the A d vanced Ironclad ent e rs th e
+game because their mighty firepo wer is useful against raiders and ironclads. Once
+you can build Advanced Ironclads, Ships-of-the-Line are all scrapped.
+Raiders.
+Ra i d e r s are the ideal ship for scouting, escorting, and raiding the merchants of
+other Great Pow e rs for many decades. They become obsolete and are scr a p p e d
+when Battlecruisers become available.
+Ironclads.
+I ronclads last until t h ey are replaced by Dreadnoughts. They are more lik e ly to
+s u rv i v e a battle than is a Ship-of-the-Line, but Ironclads do not win such
+confrontations every time.
+Armoured Cruisers.
+These Cr u i s e r s are the most efficient vessels for escorting and raiding commer c e .
+A l though the later Battlecruiser has gr e a t ly superior abilities, Ar m o u r ed Cr u i s e r s
+are much cheaper and remain adequate to the task until the end of the game.
+Advanced Ironclads.
+Ad vanced Ironclads possess an im p o rtant adv a n ta g e in r a n ge over all ear l i e r
+vessels. They are e x p e n s i v e, but are never sold for scrap. Howev e r, once
+Dreadnoughts can be built, these ships are not worth much.
+Battlecruisers.
+Battlecruisers are a luxury item; they are expensive Armoured Cruisers. If you use
+them to fight Dreadnoughts, you will be sorry. Howev e r, th ey are unmatc h e d
+against any other fastships.
+Dreadnoughts.
+D readnoughts eff e c t i ve l y dominate the seas, and sink any other vessels t h ey
+encounter. The only ships that can fight them are other Dreadnoughts.IMPERIALISM: What Happens on the Ter rain Map 42
+--- page 47 ---
+Battles.
+All fl e et inte rc e p tions and subsequent naval battles are r e s o lved s t ra te g i c a l l y and
+then r e p o r ted on the battle r e p o r t screen. The abilities summarised on the “W a rs h i p
+Sta t i stics” table control the battle. Superior r a n ge is the most im p o rtant st a t i st i c .
+Admirals and Flagships.
+As a r eward for na val expansion, you receive Admirals accompanied by a flagship.
+An A d m i r al is much be t ter at assessing enemy f o rces in his sea zone than a mere
+c a ptain or commodore. In addition, A d m i r als contr i b u te their leadership abilities
+and their flagships to the perf o rmance of the f l e et in battle. Flagships are always
+the most powerful ship available at the time the reward is received. 
+Experience.
+Ships gain e x p e r ience in the same ways as regiments. A ship with four medals is
+approximately twice as powerful as a ship of the same type with no medals.
+Escorts and Repairs.
+E s c o r ting r e fe rs to r e s e rving some of your w a rships to protect vulner a b l e
+merchants. You do not see ships escorting mer chants on the Terrain Map screen.
+To assign ships to escort, leave them anc h o red in your home port. They
+automatically escort the merchants during that turn. IMPERIALISM: What Happens on the Ter rain Map 43
+Bessemer Con verter.Henry Bessemer in vented a process of blowing air into the bottom of a vat of
+molten iron to remo ve the carbon, producing cheap, highg rade s teel.
+--- page 48 ---
+Ships that suf fer damage in battle must remain in port to be repaired. Ships canno t
+repair in the open sea. Ships undergoing repair cannot act as escorts. Only
+undamaged ships can take escort duty.
+Obsole te Warships.
+S o m e times, when t e chnology makes a new w a rship available, all the ships in one
+of the older classes are br o ken up for scrap. When obsolete w a rships are br o ke n
+up, your minis ter notifies you. The experienced cr ews are spread among the fleet,
+increasing overall navy experience.
+THE TRANSPORT NET WORK
+What is the T ransport N etwork?
+All the agr i c u l t u r al, mineral, or indus t rial products of the countries of the w o rl d
+a re called commodities. Some commodities are produced in r u ral dis t ricts; some
+a re produced only by indus t ry. Most may be traded on the w o rld marke t .
+Commodities are divided into t h ree sub-cat e g o r ies: r e s o u r ces, mat e rials, and
+goods. R e s o u r ces are commodities that are grown or mined in your country and
+not produced industriall y. At the beginning of the game, your transport network is
+concerned only with resources.
+In the early part of the game, your indus t ry obtains these r e s o u r ce commodities
+f rom the t e rrain tiles next to the capital city. Each turn, when you click the E n d
+Tu rnb u t ton, the commodities produced in these tiles move to indus t ry, becoming
+available for w o rke rs, mills, f a c to r ies, or as an increase to your cash. Some
+commodities can be traded on the w o rld market; some can be used to cons t ru c t
+military units or warships. 
+As the needs of indus t ry grow, so must the tr a n s p o r t net wo r k. The Engineer
+c o n st r ucts ports, rail depots, and r a i l roads, perhaps far from the capital city. Each
+n ew cons t ruction adds the potential for more commodities to use the ne t wo r k.
+O ther civilian units, such as F a rm e r s and Miners, develop t e rrain that is alr e a d y
+connected to produce a greater quantity of commodities each turn. 
+Transport Capacity .
+A l though the civilians w o rking on the Te rrain Map s c reen expand the pool of
+commodities which pot e n t i a l l y could be tr a n s p o r ted, your indus t ry cannot use all
+these additional commodities without the assets to tr a n s p o r t them. Tr a n s p o r t
+capacity is the total number of commodities that your ne t wo r k can move each
+turn. This number may be increased by using the rail yard building on the Industr y
+s c reen. See the “Building Tr a n s p o r t Capacity” section, st a rting on page 60 f o r
+more information.  
+Regiments can also be tr a n s p o r ted using the rail ne t wo r k, but at a much low e r
+ra te. Each armaments point that a unit has r e qu i r es fi ve points of rail capacity to
+t ra n s p o r t. For a listing of v a rious regiments armament point totals, see t h e
+“Regimental Abilities and Comparison” section, starting on page 86.IMPERIALISM: The T ransport N etwork44
+CONTENTS
+--- page 49 ---
+Rail Depots and Ports.
+These s t ru c t u r es, cons t ru c t ed on the T e rrain Map by t h e
+E n g i n e e r , expand your tr a n s p o r t net wo r k. Once connect e d ,
+d e p o ts and ports can g a ther all commodities that are in the same
+space as the depot or port, or in adjacent spaces within your country. It is more
+e fficient to build depots and ports with at least two tiles be t ween them so that t h e
+commodities of each t e rrain tile can be g a th e r ed by only one depot or port, t h u s
+avoiding duplication of effort.
+Un c o n n e c t ed depots and ports do not g a ther commodities. The capital city is always
+b oth a connected depot and a connected port. Near each depot on the map is a small
+signal post. You can tell immediat e ly that a depot is not connected if the two lights
+on the signal post are red. If the lights are green, the depot is connected. Alt h o u g h
+th e re is no eq u i valent marker for a port, ports are almost always connect e d .
+Connecting a Depot.
+Since a depot is a r a i l road station, no depot is connected without a r a i l road. A
+d e p o t is connected or unconnected depending on whether it has a tr a n s p o r t line
+to the capital city. The most obvious line is a r a i l road dir e c t ly from the tile of t h e
+d e p o t to the tile of the capital city. Howev e r, a depot may also be connected by
+rail to a tile with a port that also contains a depot. The commodities must pass
+through the second depot to reach the port and then tr avel to the capital by water .
+Connecting a Port.
+Ports may be built only on coasts and tiles containing a river. They cost more than
+d e p o ts. Howev e r, th ey are much easier to connect than are depots since no
+railroad must be built. In general, a port is alw ays connected. Ho wever, if you lose
+control of a pr ovince downstream from a river port, your port has no access to the
+sea and may not be connected. 
+If you choose to build a port on a coast distant from your capital and then build
+ra i l roads inland from the port, remember to cons t ruct a depot in the same space
+as the port. W i thout this additional depot, the port itself is connected, but t h e
+f u t u r e depots cons t ru c t ed along your new r a i l road have no way to move t h e i r
+commodities to the port.
+How Connections are Lost.
+Connections are lost when a province some w h e r e along the line to the capital is
+ta ken; for ex a mple, when a province containing a r a i l road is t a ken, or when a
+province downstream from a river port is lost. Sea ports can lose their connections
+o n ly by hostile f l e et blockades. If an enemy f l e et is in undisputed command of a
+sea zone, the ports adjacent to that sea zone lose their connection. U n d i s p u te d
+command means that you have no w a rships present in the sea zone cont a i n i n g
+the enemy f l e et. As long as any of your ships are present, the ports maintain t h e i r
+connections.IMPERIALISM: The T ransport N etwork 45
+--- page 50 ---
+Using the T ransport N etwor k.
+Getting to the T ransport screen.
+From the Te rrain Map s c reen t o o l b a r , click on the Go to T r a n s p o r tb u t to n
+w i th the cargo container and small arrow on it. This button appears in a
+lighter colour each turn until you ha ve visited the Transpor tscreen during
+that turn.
+How to Read and Use the T ransport Screen.
+The Tra n s p o r ts c reen is displayed as an open book. All commodities that could be
+t ra n s p o r ted appear on one of the two pages, but only commodities pr e s e n t l y
+available to you are in colour. Next to each of the available commodities is a slider
+for controlling how much of your total tr a n s p o r t capacity you want to use to
+t ra n s p o r t that commodity. The numbers under the slider indicate how much of t h e
+commodity is being tr a n s p o r ted com p a red to the total amount of the commodity
+you have available. You can place your cursor over the commodities and read t h e
+h ot text at the upper right to remind you what these commodities ar e .
+Click on the arrows at either end of the sliders to increase or decrease the amount
+t ra n s p o r ted of each commodity. As you increase the amount, you use some more
+of your total tr a n s p o r t capacity, as shown by the coloured bar in the lower r i g h t
+section of the book. The numbers under that bar show you how much tr a n s p o r t
+capacity is being used com p a red to the total amount of tr a n s p o r t capacity you hav e .
+You may increase transport capacity in the Railyard building. IMPERIALISM: The T ransport N etwork46
+CONTENTS
+Jump to Order Screens
+Help & Information
+Unavailable Commodity
+Transport Capacity BarReturn t o
+Terrain Map
+Commodities
+Demand Lines Commodity Slider s
+--- page 51 ---
+Industry and Wor ker Demands.
+C o l o u r ed red or green lines called demand lines appear under n e a th many of t h e
+s l i d e r s on the Tra n s p o r ts c reen. The demand lines offer im p o rtant inf o rm a t i o n
+about the needs of industry and wor kers. A g reen line means that the cur rent le vel
+of tr a n s p o r t for that commodity is enough or more than enough for curr e n t
+demand taking your warehouse s tockpile into account. If the commodity is a food,
+the demand comes from w o rke rs who need to eat. If the commodity is an
+i n d u st r ial one, the demand comes from the mill or f a c to r y that r e qu i r es th a t
+commodity for production. A red line means the indus t ries or w o rke rs re qu i r e
+m o re of that commodity. The hot text shows you the exact number r e qu i r ed by
+industry when the cursor is moved over a particular line.
+Since the success of your trading with other countries is not pr e d i c t able, t h e
+demand indicators do not take account of potential trade deliveries from abroad.
+Transport Example: Using Demand Lines.
+You are tr a n s p o r ting six grain per turn, and the line under the grain slider is red, t e l l i n g
+you that the w o rke rs want more grain. If you expect to buy significant quantities of
+canned food on the w o rld market, you may not need to c h a n g e your or d e rs or e x p a n d
+the amount of grain available on your ne t wo r k. Ot h e rwise, you should t a ke steps to
+t ra n s p o r t more grain to ensure your w o rke rs do not get sick or st a rve .
+Possible Commodities to T ransport.
+At the beginning of the game you may only tr a n s p o r t re s o u r ces from the country s i d e
+to indus t ry. Lat e r, your r u ral dis t ricts may develop small indus t ries in the to w n s .
+This permits expansion of your tr a n s p o r t net wo rk to mat e rials and goods.
+Industrial Resources.
+These resources mo ve directly to the industry warehouse where they are a vailable
+for production or trade the turn after you tr a n s p o r t them. Since the w o rld pr i c e s
+of indus t rial re s o u r ces tend to be low, these commodities are most useful to y o u
+when you use them, along with wor kers and industr y, to produce a more expensiv e
+m a te r ial. If your indus t ry does not r e qu i r e the e x t ra indus t rial re s o u r ces, consider
+transporting something else, such as food, instead.
+Coal and Iron.
+Coal and iron are r e qu i r ed by your steel indus t ry in eq u a l
+amounts. In the absence of other sources of one or the ot h e r, such
+as a surplus in the w a rehouse or f o reign deliv e ries, you should
+t ra n s p o r t coal and iron in equal amounts. Later in the game you may find a
+greater need for coal when some of your ships require it for fuel.
+Wool and Cotton.
+Since wool and cotton may be used inter changeably by your t extile
+mill, one slider on the Tra n s p o r ts c reen suffices for both
+commodities.IMPERIALISM: The T ransport N etwork 47
+CONTENTS
+--- page 52 ---
+Timber .
+The lumber mill requires timber to produce lumber and paper.
+Food Resources.
+Your indus t rial w o rke rs try to consume tr a n s p o r ted food each turn; e x t ra food is
+m oved to the w a rehouse. Each individual w o rker enjoys only one type of food. This
+means you must tr a n s p o r t all t h ree food types to satisfy as many w o rke rs as possible.
+Wo rke rs fo rced to eat a type of food t h ey do not enjoy r e p o r t sick and stay home
+from work on that turn. 
+E ven though food r e s o u r ces cannot be traded on the w o rld market, you should
+consider transporting extra food whene ver you can. S tored food feeds your hung ry
+wo rke rs when enemies int e rfe re with the tr a n s p o r t net wo r k. In addition, in t h e
+food processing centre you may produce canned food from your st o red food. F o r
+m o re inf o rmation on how w o rke rs eat and how food is used see the “W o rke rs ”
+section, starting on page 53. 
+Canned food may be traded or used to r e c ruit more w o rke rs to your indus t ry.
+I n d u st r ial w o rke rs eat canned food r e s e rves, if available, in pr e fe rence to an undesir e d
+food r e s o u r ce and r e p o rt to w o rk nor m a l ly after consuming the canned f o o d .
+Grain.
+One-half of your w o rke rs try to eat grain ev e ry turn. Grain f a rms dot t h e
+landscape of most Great Pow e rs, so you should be able to find and tr a n s p o r t
+additional grain when an increasing population demands more supplies. 
+Fruit.
+O n e - qu a r ter of your w o rke rs try to eat fruit ev e ry turn. Try to cons t ru c t
+your transport network with access to orchards.
+Lives tock and Fish.
+The remaining w o rke rs desire liv e stock or fish; either one is
+accep table. Although lives tock ranches can be rare, you can satisfy
+demand by constructing ports and obtaining fish to transport.
+Other Resources.
+H o rses are used in the ar m o u r y to build milit a ry units and can be stockpiled in
+the w a rehouse. Gold and gems never r e a ch the indus t ry wa rehouse and t h ey
+cannot be traded. Ins tead, all gems and gold transpor ted con vert immediately int o
+cash. You can benefit from gems and gold in an unconq u e red nation t h rough t h e
+ove rseas pr o fits fe a t u r e, but this does not use the tr a n s p o r t net wo r k. For more
+i n fo r mation on developing Minor Nations see the “W o rking in Other Countr i e s ”
+section, starting on page 29. IMPERIALISM: The T ransport N etwork48
+--- page 53 ---
+Horses.
+Generall y, you do not need to transport horses e very turn, since their onl y
+use is cons t ruction of cav a l ry and ar t i l l e r y regiments. Build up a st o c k p i l e
+of a few horses in the w a rehouse and then use the tr a n s p o r t capacity to
+bring in something more immediately useful.
+Gold.
+Gold may be found in mountain t e rrain. Each unit of gold tr a n s p o r te d
+increases your cash by $200.
+Gems.
+L i ke gold, gems may be found in mountains. Howev e r, unlike gold, g e m s
+can only be found in Minor Nations. To obtain gems for your tr a n s p o r t
+n et wo r k these nations must be conq u e red. Tr a n s p o r ted gems conv e rt to
+cash at $500 per unit.
+T own Development.
+Each pr ovince you own includes a t own. At the beginning of the game, these t owns
+p roduce nothing. Howev e r, if a connected rail depot or port is placed on or ne x t
+to the town, industrialisation begins there.
+Materials.
+O ver time, a connected town begins to pr o d u c e
+m a te r ials that are added to the tr a n s p o r t net wo r k and
+appear in the Tra n s p o r ts c reen. The type of mat e ri a l s
+produced depends on the resources a vailable within the pr ovince of the t own. The
+quantity of mat e rials produced depends on the capacity of the indus t ry th a t
+demands those mat e rials. The to w n’s gro w th is r e p re s e n t ed on the map by
+additional buildings (one of them is a windmill) when the f i rst mat e rial is
+produced. T owns produce only s teel, lumber, and fabric. Other materials must be
+produced on the Industry screen or purchased on the world market.
+Goods.
+Once mat e rials become available, the town begins to
+d evelop the capacity to produce goods as well. The
+tow n’s gro w th to this level is r e p re s e n t ed on the map by
+additional buildings including a f a c to r y with smok e sta c ks. The type of goods
+eve n t u a l l y available depends on the mat e rials being produced; the maximum
+quantity of goods available in the town is always one-half the quantity of t h e
+m a te r ials available. Towns can produce consumer goods, t h ey can not pr o d u c e
+a rmaments. Armaments must be produced on the I n d u st r ys c reen or purc h a s e d
+on the world market.IMPERIALISM: The T ransport N etwork 49
+--- page 54 ---
+Example: Industrial Gr owth of a T own.
+A province consisting pr i m a ri l y of f o re sted land, eight f o re st tiles, includes a to w n
+with an adjacent connected rail depot. When the furniture factory of the Industr y
+s c reen r e a ches capacity four the town grows and begins to produce one unit of
+lumber per turn. Since there are eight forest tiles, the maximum amount of lumber
+that could be produced by the t own is four per turn, and the t own slo wly climbs t o
+this level. This production does not reduce timber production, it is in addition to
+the timber already produced in the pr ovince. Once maximum lumber production
+is attained, the town begins to develop its fur n i t u r e output and grows ag a i n .
+Maximum fur n i t u r e output is two units per turn, or one-half the production of
+lumber by that town
+INDUSTR Y
+What is Industry?
+I n d u st r y is the process by which the commodities you tr a n s p o r t and t h e
+commodities you trade for are s tored and used for production into more expensiv e
+or useful commodities. You also build all your units on the I n d u st r ys c reen. Each
+t u rn, when you click the End T u rnb u t ton on the Te rrain Map s c reen, all t h e
+p roduction or d e rs you ent e red on this screen are carried out. Whatever you build
+is available the following turn. 
+Going to the Industry Screen.
+From the Te rrain Map s c reen t o o l b a r , click on the Go to Industry b u t to n
+w i th the smoking f a c to r y on it. This button appears in a lighter colour
+each turn until you have visited the Industry screen during that turn.IMPERIALISM: Industr y50
+CONTENTS
+Trade School
+Return to Ter rain Map
+Available Labour
+Types or Wor kers
+Armour yUniversity
+Warehouse ShipyardFood
+ProcessingJump t o
+Orders Screens
+Lumber Mill
+Furniture Factor yCapitol BuildingTextile MillHelp & Information
+Railyard
+Food Demand
+Future De velopment Sit e
+Steel Mill
+Metal Wor ks
+Clothing Factor y
+--- page 55 ---
+Under standing the Buildings.
+E a ch building on the I n d u st r ys c reen r e p resents one type of your nation’s
+industr y. To find out which building is which, mo ve your cursor o ver the buildings
+and read the hot t ext in the upper right of the screen. Clicking on a building brings
+up a production dialog for that building. These dialogs may be left open from 
+turn to turn. 
+On the right side of the screen, the buildings represent industries such as Steel and
+Lumber Mills. Movement, such as men sawing, at one of these buildings means
+that w o rk is being perf o rmed t h e re. The other buildings on the screen permit y o u
+to construct new units for the Ter rain Map, to build mer chant marine, to increase
+t ra n s p o r t capacity, to stockpile commodities, to produce canned food, and to
+improve and expand your work force. 
+Information in the Industry Screen Borders.
+On the left border of the screen, you see the make-up of your w o rk fo r ce. The
+number beneath the labour icon (the muscular arm) decreases as you allocate
+labour to v a rious t a s ks. The numbers beneath the w o rker icons stay const a n t
+th roughout the turn; t h ey show the types of w o rke rs which cons t i t u te your labour
+force. An untrained wor ker supplies one point of labour per turn. T rained wor kers
+supply more labour (two per turn); expert wor kers supply the most (four per turn).
+H ot text reminds you which type of w o rker is which, as does the colour of t h e
+wo rke r’s cov e rall: gray for untrained w o rke rs, light blue for trained w o rke rs and
+dark blue for expert workers.
+All wor kers eat food e very turn. The amount of food demanded each turn appear s
+on the right border of the screen. The food shown r e p resents the ideal balanced
+d i et. Wo rke rs eat any type of food to prevent their own st a rvation, but if t h ey do
+not g et the type of food desired they become sick and per form no labour that turn.
+You can a void the consequences of an unbalanced diet by s tockpiling canned food
+in the w a rehouse. W o rke rs who find none of the desired type of food, eat canned
+food before they eat food that makes them sick. Wor kers do not g et sick when the y
+eat canned food.
+Using the Warehouse.
+The W a rehouse, near the top centre of the Indus t ry screen, is the only building
+w i th a pur e ly inf o rmational function. It lets you know how much of each
+commodity you have available. These commodities are used up and produced in
+the other buildings on the screen. If you lea ve the warehouse dialog open and giv e
+o rd e r s in a diff e rent building’s dialog, you see the items that are used in t h a t
+building deducted from the warehouse. 
+The commodities in the w a rehouse are available for trade. When you go to t h e
+Bid and Off e rss c reen, the commodities in the w a rehouse at that moment are
+what you can offer for sale.IMPERIALISM: Industr y 51
+CONTENTS
+--- page 56 ---
+Production Economies.
+The warehouse dialog is or ganised in sections according to production economies.
+In I M P E R I A L I S M a production economy is a two or t h ree level diagram outlining
+h ow a given indus t ry wo rks. The f i rst level commodities in the diagrams are
+a l ways called r e s o u r ces — usually items that can be grown or mined. The second
+level commodities are called materials and are produced from resources. The thir d
+level commodities — called goods — are made from materials.
+M o s t of the economies have t h ree levels and r e qu i r e two production buildings,
+one to t a ke in r e s o u r ces and make mat e rials and another to t a ke in mat e rials and
+m a ke goods. A tw o - l evel economy has only one building to produce the mat e ri a l s
+from the resources.
+All production within the economies is on a two-for-one basis. For e xample, in the
+textile economy two co t ton or wool are r e qu i r ed to make one unit of f a b ric. T wo
+units of f a b ric are r e qu i r ed to make one unit of clothing. The details of each
+economy are explained below.
+Production Economies Table.
+Products. Resources. Materials. Goods.
+Textile Economy Wool and Cotton Fabric (made by 2 cotton or wool) Clothing (made by 2 fabric)
+Wood Economy Timber Lumber and/or Paper Furniture 
+(each made by 2 timber) (made by 2 lumber)
+Metal Economy Iron and Coal Steel (made by 1 iron and 1 coal) Hardware and/or Armaments
+(each made by 2 steel)
+Oil Economy Oil Fuel (made by 2 oil)
+Food Economy Grain, Fruit, Canned Food 
+Livestock, and Fish (2 canned food made 
+by 4 raw food)
+Horse Economy Horses
+Labour .
+The buildings on the I n d u st r ys c reen that produce commodities r e qu i r e
+labour to make the next le vel commodity from the input commodities. For
+example, you might ha ve plenty of cotton or wool in your Warehouse, but
+without some labour you cannot produce fabric. 
+Labour is symbolised by a muscular arm icon. The number shown with the arm
+tells you the total amount of labour supplied by all your available w o rke rs, and
+your available pow e r. This number appears on the left bor d e r, and in t h e
+Wa rehouse dialog. Each turn, as you assign labour, this number goes do w n ,
+showing you the amount remaining available.IMPERIALISM: Industr y52
+CONTENTS
+--- page 57 ---
+Workers.
+Wo rke rs supply an amount of labour det e rmined by their training level. When
+n ew wo rke rs migr a te to indus t ry, their untrained eff o rts supply only one unit of
+labour per turn. A trained w o rker supplies twice as much labour at two per tur n ,
+and an expert worker supplies four per turn.
+Trade School and T raining.
+The Trade School, located on the left side of the I n d u st r ys c reen, im p roves t h e
+labour output of your w o rke rs. Click on the red brick building to open the Tr a d e
+S chool dialog. Training costs paper and cash. If the amount of cash or paper y o u
+have is insufficient, the item has a red “X” next to it. 
+Training a w o rker t a kes him out of the labour pool for the turn. If you open t h e
+t rade school dialog after assigning all of your available labour to f a c to r ies and
+mills, you cannot train. Of course, you can free up labour by opening a f a c to r y or
+mill dialog, reducing the number of w o rke rs assigned, and then re t u rning to t h e
+Trade School dialog to assign them to train. 
+Capitol Building and Mig ration.
+The white Capitol building near the centre of the I n d u st r ys c reen controls y o u r
+m i gration policies. Click on the building to open the Capitol dialog. To r e c ru i t
+ru ral w o rke rs for indus t ry you need to supply them with the comf o rts of a
+developing economy: canned foods, clothing, and furniture.
+You may r e c ruit untrained w o rke rs using this dialog during ev e ry turn, when y o u
+h ave the necessary commodities. Howev e r, the size of your country limits t h e
+number of w o rke rs that migr a te during one turn to one-f o u rth of the number of
+p rovinces you own, rounded down. Later in the game, your Capitol building may
+u p grade in response to successful f o reign policies. Then the limit becomes one-
+third of the number of provinces owned.
+Be careful not to increase your population too f a st. In addition to the cost of
+re c ruiting the new w o rke r, you have to supply the w o rke rs with food each tur n .
+This can be dif ficult until you ha ve established a lar ge capacity transport networ k,
+or a reliable source of imported food. 
+Food Consum ption.
+To be able to supply any labour, all w o rke rs must eat one unit of food per tur n ;
+each wor ker has a prefer red type of r aw food that he wants to eat. If fed the wrong
+type of food, a w o rker gets sick and refuses to w o rk. If fed no food at all, a w o rke r
+starves, and is removed from your industrial system.IMPERIALISM: Industr y 53
+
+--- page 58 ---
+To understand how w o rke rs’ food pr e fe rences are det e rmined, think of them in
+groups of f o u r. Wi thin this group the f i rst wo rker eats grain, the second eats fr u i t ,
+the t h i rd eats grain, and the last w o rker eats either liv e stock or f i s h
+i n te r ch a n ge a b l y. The count st a rts again, so the f i fth w o rker eats grain. F o o d
+preferences are independent of the type of worker (expert, trained, or untrained). 
+Consumed food is deducted from the amount tr a n s p o r ted to indus t ry when y o u
+click the End T u rnb u t ton. If you do not tr a n s p o r t sufficient amounts of the corr e c t
+types of food for all your w o rke rs, some w o rke rs eat by deducting food of t h e
+d e s i r ed type from your w a rehouse. If t h ey fail to find their desired type of food in
+the w a rehouse, t h ey eat any available canned food from the w a rehouse. As a last
+re s o rt, the hungry w o rke rs eat surplus food of the wrong type and get sick. If
+workers find no food of any kind, they starve to death. 
+Satisfying Your Food Needs.
+Canned food is one of the r e qu i r ements to draw migrants to indus t ry. It is also
+ex t re m e l y useful as a r e s e rve stockpile, since the r e qu i r ements of any w o rker can
+be met by eating it. Of course, you may trade for canned food on the world mar ket.
+H oweve r, if you are f o rt u n a t e enough to possess a surplus of all raw food types,
+you can produce your own canned food in the Food Processing Centre.
+Food Processing.
+The production dialog for the Food Processing Centre also functions just like one
+for a f a c to r y or mill ex c e pt that t h e re is no capacity limit. You can produce as
+much canned food as you want to as long as you ha ve grain, fruit, and lives tock or
+fish. Production t a kes place according to the same ratio of foods that the w o rke rs
+eat. This means that two g rain, one fruit, and one fish or lives tock are required for
+every two units of canned food produced.
+Since it is unlikely that you will want to make food e very turn, orders to this centr e
+are not saved. 
+Pow er.
+Power is not a commodity. It cannot be sold or st o red in the W a rehouse and it
+re qu i r es no labour to cr e a te. Howev e r, on the turn when it is cr e a ted, power adds
+d i re c t l y to your labour total. Power is g e n e ra t ed by building a Power Plant on t h e
+Industr yscreen. The option to build a P ower Plant and an Oil Refinery becomes
+available once Oil Drilling technology is purchased. 
+Creating P ower.
+Power is created in the P ower Plant in the same turn it is used. As you increase the
+amount of fuel used by the plant, your available amount of labour r i s e s
+automaticall y. With enough po wer, you can free a lar ge segment of the work force
+to expand the army, or the number of civilian units.
+Using P ower.
+Power is used aut o m a t i c a l l y when you allocate labour in a production dialog. It is
+used in advance of any of your human labour.IMPERIALISM: Industr y54
+--- page 59 ---
+Building Units.
+E a ch of the t h ree unit cons t ruction centres; the U n i ve rs i t y , the Ar m o u r y, and t h e
+S h i p ya rd, builds a diff e rent sort of unit: civilians, land regiments, and ships
+re s p e c t i ve l y. All new units (with the ex c e ption of merchant ships) appear on t h e
+Te rrain Map s c reen at the st a rt of the next turn. All new units (including
+m e rchant ships) are announced by one of your Minist e rs at the st a rt of the ne x t
+t u rn. New units st a rt their f i rst turn on the T e rrain Map, in the province of t h e
+capital, or in port at the capital.
+In all t h ree cons t ruction centres, units are built in the same way. Once the dialog
+is open, click on the picture of the desired unit to select it. Then control t h e
+quantity to be built using the arrows under n e a t h each unit picture. The display
+provides information on each type of unit as that unit is selected.
+University .
+All civilian units r e qu i r e ex p e r t wo rke rs, cash, and paper. If you are short of one
+or more of these items, the short a ge appears in red text on the inf o rmation panel
+on the U n i ve r sity dialog. It is im p o rtant not to build too many civilian units,
+e s p e c i a l l y early in the game. Each unit cons t ru c t ed costs you an e x p e r t wo rke r
+f rom your indus t ry, where it supplied a valuable four units of labour each tur n .
+Build only what you need. Consider disbanding civilians when you are short of
+labour for industry.
+At the beginning of the game you can cons t ruct only four types of civilians: t h e
+Fa rm e r , the Miner, the Pr o s p e c to r , and the Engineer. Soon after the game begins,
+you can inv e st in Feed Gr a s s e s te chnology and I ron R a i l road Br i d ge s te ch n o l o g y .
+These developments permit the cons t ruction of the R a n cher and the F o re ste r
+re s p e c t i ve l y. Lat e r, Oil Dr i l l i n g te chnology permits cons t ruction of Dr i l l e rs. IMPERIALISM: Industr y 55
+CONTENTS
+Picture of Selected UnitMiner to be Built
+Arrows for “Placing” OrderCost of Selected Unit
+Abilities of Selected Unit
+--- page 60 ---
+The information panel for each unit type, found at the lo wer-left of the University
+dialog, provides production inf o rmation according to your current level of
+te ch n o l o g y . For ex a mple, at the st a rt of the game, the Miner w o rks at pr o d u c t i o n
+l evel “1,” so you see a column of production numbers beneath the number “1.”
+This column provides the per turn output of a mine for each type of miner a l .
+Information on other civilian units is organised in a similar fashion. 
+To view the uses of the v a rious civilians see the “W o rk of Civilian Units” section,
+starting on page 25. 
+Armour y.
+Regiments for your army r e qu i r e cash, armaments, and w o rke rs. Gener a l ly, more
+p owe rful or more specialised units r e qu i r e wo rke rs with prior training. Some
+regiments also require fuel or horses. If you are short of one or more of these items,
+the shor tage appears in red t ext on the information panel on the Armoury dialog.
+The gr e a te s t cost to you, especially in the long run, is the loss of w o rke rs. They
+can be upg raded to a more advanced type of regiment as new military technology
+is purchased, but they can never return to industry.
+The or ganisation of the units on the Armoury is by generic category of regiments.
+This means that the best a vailable regiment within a generic category at any given
+time is the only one you can cons t ruct of that cat e g o r y at that time. The eight
+ge n e r ic cat e g o r ies are: Light Inf a n t ry, Regular Inf a n t ry, Heavy Inf a n t r y, Light
+C ava l ry, Heavy Cav a l ry, Light Ar t i l l e r y, Heavy Ar t i l l e r y, and Combat Engineer s .
+Each category always appears in the same position on the Armoury dialog.
+Example of Armoury Construction.
+At the beginning of a random w o rld game it is 1815 and you have a “N a p o l e o n i c
+Era” regiment a vailable in all eight unit categories. Your Heavy Infantry categor y,
+for instance, off e rs G re n a d i e r s , while your Light Cav a l ry cat e g o r y off e rs H u s s a r s .
+When you in vest in a new technology, the Bessemer Con verter , the picture of the
+Hussars disappears and is replaced b yScouts . At this point, you can no longer build
+H u s s a r s ; your Light Cav a l ry cat e g o r y off e rs only the superior regiment, S c o u t s .
+H oweve r, you could still build a G re n a d i e r regiment, until a diff e rent t e ch n o l o g y
+updates the Heavy Infantry category.
+For details on the diff e rent regiments and the cat e g o r ies see the “R e g i m e n t
+Categories” section, starting on page 32.
+D u ring the game, rew a rds resulting from your milit a ry success can im p rove t h e
+Armoury, allowing you to construct troops who start with experience medals.IMPERIALISM: Industr y56
+--- page 61 ---
+Ship yard.
+Ships require lumber and/or s teel for their hulls and fabric, coal, or fuel for motiv e
+power. Warships require armaments. If you are short of one or more of these items,
+the short a ge appears in red text on the inf o rmation panel on the Shipy a rd dialog.
+Ships do not r e qu i r e wo rke rs, allowing you to increase your navy and merc h a n t
+marine without decreasing your labour force for industr y. However, since ships do
+re qu i r e large amounts of precious commodities, ov e r- c o n st r uction can slow y o u r
+early development.
+Mer chant Ships.
+M e rchant ships do not appear on the t e rrain map. Instead, each merchant ship
+you cons t ruct adds its cargo capacity (the number of cargo holds) to the total y o u
+h ave available each turn for trade. If you build f a ster ships, the av e ra g e sailing
+speed of your merchant marine increases, making blockade and int e rc e pt i o n
+m u c h more difficult for hostile navies. You must consider both speed and car g o
+capacity when deciding which merchant ships to cons t ruct. F i ve types ev e n t u a l l y
+become available: the Tr a d e r, the Indiaman, the Steamship, the Clipper, and t h e
+Freighter. 
+Warships.
+Warships mo ve on the ter rain map in fleets. As your navy g rows you receive bonus
+ships, called flagships, each carrying an admiral who helps you in sea combat.
+Un l i ke regiments, ships cannot be upgraded and do ev e n t u a l l y become obsolet e .
+An obsolete ship is broken up. 
+T h e r e are eight ship types available in the game, which can be divided into fa st
+ships and b a t t l e ships. The four fa stships, Fr i ga tes, R a i d e r s, Ar m o u r ed Cr u i s e rs ,
+and Battlecr u i s e r s, are most eff e c t i v e at blockading or int e rc e p ting merc h a n t s ,
+scouting, and escorting convoys. They should not be used in battles to dominate
+sea zones unless the enemy uses b a t t l e ships from an earlier era than your fa sts h i p s .
+The four b a t t l e ships are Ships-of-the-Line, Ironclads, A d vanced Ironclads, and
+D readnoughts. Each of these can dominate the sea during its era and has a good
+chance against the fastships of later eras. 
+In sea combat, four factors influence the battle. Speed, firepo wer, and armour ar e
+all im p o rtant, but the controlling f a c tor is r a n ge. The later w a rships can f i re so
+m u c h further than those built early in the century, that one Dreadnought, f o r
+example, can sink a large number of Ironclads by itself. 
+Building Industr y.
+On I n t ro d u c t o r yand E a s y s ettings, six indus t rial buildings are cons t ru c t ed for y o u .
+You need not be concerned with cons t ructing indus t ry until the oil r e fi n e r y
+becomes a vailable later in the game. On Normal ,Hard, or Nigh-On-Impossible settings,
+you must construct your own industry from the beginning.IMPERIALISM: Industr y 57
+CONTENTS
+--- page 62 ---
+Industry Constructor .
+When factories and mills do not exist, click directly on the future site of the mill or
+fa c to r y to cons t ruct them. Use the hot text in the upper right of the screen to
+c o n fi r m which site is which. A click on the site brings up the cons t ru c t or dialog
+for that factory of mill. You can confirm or cancel construction of the building.
+Production Equations.
+On the cons t ru c t or dialog, you see a production equation, made up of icons f o r
+the f a c to r y or mill explaining the function(s) of that building. The text above t h e
+e quation explains it in more detail. The most im p o rtant indus t ries to build early
+in the game are the Lumber and S teel Mills. F rom the equations, you can see these
+buildings are used to produce lumber and steel. Since lumber and steel are used
+for all indus t rial expansion, you must cons t ruct a lumber and steel mill with y o u r
+initial stockpiles of lumber and steel, or you may be f o rced to beg for lumber and
+steel from other Great Powers.
+Cost of Construction.
+When a mill is fir st built it is alw ays capacity “2”; a factory begins at capacity “1 .”
+For each point of capacity built, you pay one lumber and one steel from y o u r
+Wa rehouse. This same cost applies later in the game when you enlarge y o u r
+industries.
+Expanding Industr y.
+When you ha ve excess labour and commodities on your industr y
+s c reen, it’s time to expand your indus t ries. In the pr o d u c t i o n
+dialog of an indus t ry, locate the Expand Industry b u t ton in t h e
+u p p e r- r ight corner of the dialog. This brass button has an icon of smaller f a c to r y,
+an arrow, and a larger factory.IMPERIALISM: Industr y58
+CONTENTS
+
+--- page 63 ---
+When you click on the Expand Industry b u t ton an Expansion dialog appears. Here y o u
+can conf i rm that you want expansion or cancel expansion for this turn. The cost in
+lumber and steel is listed on the dialog and a picture of the new building is shown. 
+Industrial Capacity .
+Capacity (size) is im p roved only in certain increments. For mills, which st a rt at
+capacity “2,” the im p rovement levels are capacity “4,” “8,” “1 6 ,” “24” and t h e n
+continue to increase by eight at a time. For factories, which s tart at capacity 1, the
+impr ovement le vels are “2,” “4,” “8,” “12” and then continue to increase four at a
+time. The indus t rial capacity of a f a c to r y or mill is the maximum output in any
+one turn.
+Giving Orders to Industr y.
+All or d e rs to indus t ry are given on production dialogs, floating windows t h a t
+appear when you click on one of the buildings. Each dialog includes a pr o d u c t i o n
+equation showing you what the building can do, and a slider, or sliders, where you
+e n ter the amount of the output commodity you want to produce. For buildings
+that have two possible outputs, two sliders are provided, though the capacity y o u
+can produce is a combination of what you enter on both sliders.
+A red “X” near an item in a production equation tells you that you have no more
+of that item available. Additional production cannot be or d e red until that missing
+item is supplied.
+All production or d e rs at f a c to r ies and mills are saved to the next turn. Even if t h e
+wa rehouse stockpile sustains t e mp o ra r y short a ges which lower production, t h e
+building “remembers” how many output units you wanted and continues to try t o
+fill the order each turn. Howev e r, if you open the production dialog, the memory
+of the building r e s ets on whatever or d e rs are shown on the dialog after you give
+(or fail to give) your new orders.IMPERIALISM: Industr y 59
+CONTENTS
+
+--- page 64 ---
+Industrial Input and Output Table.
+Industrial Building. Input Commodities. Output Commodities.
+Textile Mill Wool or Cotton Fabric
+Clothing Factory Fabric Clothing
+Lumber Mill Timber Paper or Lumber
+Furniture Factory Lumber Furniture
+Steel Mill Coal and Iron Steel
+Metal Works Steel Hardware or Armaments
+Refinery Oil Fuel
+Food Production Grain, Fruit, Fish, Livestock, Canned Food
+Building T ransport Capacity .
+When you have plenty of labour and your f a c to r ies are not full, you need to br i n g
+m o re commodities to indus t ry each turn. One way to do this is to incr e a s e
+t ra n s p o r t capacity. As with other indus t rial expansion, increasing tr a n s p o r t
+capacity requires both lumber and steel.
+Railyard.
+The production dialog for the r a i lya rd diff e rs from the production dialogs for a
+factory or a mill in that there is no capacity limit. You can build as much transpor t
+capacity as you want, provided you have steel, lumber, and available labour.
+Since it is unlik e ly that you will want to increase tr a n s p o r t capacity ev e ry tur n ,
+these orders are not saved. IMPERIALISM: Industr y60
+CONTENTS
+
+--- page 65 ---
+TRADE
+What is T rade? 
+D u ring each turn, all the Great Pow e rs and Minor Nations in the w o rld att e mpt
+to buy and sell commodities on the world mar ket. You need to trade to obtain cash,
+to provide your indus t ries with r a re re s o u r ces or mat e rials, and to dev e l o p
+economic control over Minor Nations. 
+Using the Bid and Off e rss c reen, you offer commodities for sale, and enter bids
+for commodities you hope to buy. Each turn, when you click the End T u rnb u t to n
+on the Terrain Map screen, you may receive of fers to buy some or all of the items
+you bid on, and the items you off e red for sale may be sold to other countries. If
+you accept an offer to buy, the commodities you buy appear for your use in t h e
+I n d u st r ys c reen next turn. Commodities you sell are deducted from t h e
+warehouse of your Industry screen. 
+Going to the Bid and Of fers screen.
+From the Te rrain Map s c reen t o o l b a r , click on the Go to T r a d eb u t ton with
+the dollar sign on it. This button appears in a lighter colour each tur n ,
+until you have visited the Bid and Offers screen during that turn.
+The Bid and Of fers screen Displa y.
+E a ch row on the Bid and Off e rss c reen provides inf o rmation about one
+commodity, represented by an icon at the left end of the r ow. When you place your
+mouse cursor over the icon, hot text in the upper right section of the scr e e n
+identifies the commodity.IMPERIALISM: Trade 61
+CONTENTS
+Current T reasur y Jump to Orders Screens
+Quantity Of fered Slider
+Amount on Hand World Prices at
+Start of Tur nT otal Mer chant 
+Marine CapacityHelp & Information
+Offer Bar s
+Bid Bar s
+--- page 66 ---
+In the row you see a box for the current w o rld price and for the amount of t h e
+commodity available in your w a rehouse after deduction of the commodities y o u
+have ordered for production on the Industr yscreen. You cannot sell items you do
+not own or that you have ordered industry to use this turn.
+Under standing T rade.
+The economy of I M P E R I A L I S M i nvo lves short a ges and com p etition f o r
+commodities. Wanting a r e s o u r ce such as coal, for ex a mple, and bidding on it,
+does not guar a n tee that your Great Power r e c e i v es coal that turn. Your success
+depends on the world price of coal, your Great P ower’s trade policies t oward coal-
+p roducing countries, and the diplomatic relationship be t ween your Great Pow e r
+and the other countries in the world. 
+Once all the Great P owers and Minor Nations enter their of fers to sell and bids t o
+buy, and all Great P owers end their turns, a list of the po tential trade deals for this
+turn is created. The commodities for sale appear as of fer sheets for the decisions of
+the rulers of all bidding countries. For more information see the “Receiving T rade
+Offers” section, starting on page 67. 
+Example: Of fers of a T rade Deal.
+On a turn when the Minor Nation of Belgium decides to sell coal, all of the coal it
+o ffe rs fi rst appears as an Offer Sheet to Great Br i tain, the most fav o u red tr a d i n g
+p a rtner of Belgium, which bid to buy coal this turn. If the ruler of Br i tain decides
+to buy only some (or none) of the off e red coal, then the coal remaining (of
+B e l g i u m ’ s offer) passes to the next coal-bidding country on the list of Belgium’s
+favo u ri t e trading par t n e rs. This process continues until the bidders purchase all
+the offered coal or until there are no more coal bidders. 
+Your goal is to put your Great P ower at the top of the f avoured trading partner lis t
+of as many other countries as you can. Try to concentr a te on potential tr a d i n g
+p a rt n e r s that produce the commodities you most need. You must consider and
+wo rk with a v a ri ety of f a c to r s, including w o rld prices, trade policies, and
+diplomatic relationships.
+Prices.
+The prices shown on the Bid and Off e rss c reen are the w o rld market prices f o r
+the commodities traded during the previous tur n. This price is a s tarting point for
+this tur n’s price, which may go higher or lo wer depending on supply and demand.
+If, during this turn, demand for a commodity is stronger than the suppl y, the price
+rises. If the rev e rse is true, the price falls. If supply and demand are closely
+matched, the price this turn remains much the same as last turn’s price.
+All Minor Nations, and sometimes Great Pow e rs as well, decide which of t h e i r
+p roducts to offer for sale, based in part on the w o rld market price from last tur n .
+As prices rise, more countries offer the product for sale. Ev e n t u a l l y, the new
+supplies begin to drive prices down again.
+When you enter your bids and off e rs, it is impossible to predict the final price f o r
+this turn, because the buy bids and sell off e rs which det e rmine the price come
+from all the countries in the game, not just from your own Great Power.IMPERIALISM: Trade 62
+--- page 67 ---
+Trade Subsidies.
+Because obtaining scarce r e s o u r ces can be difficult, especially at the beginning of
+the game, your tr a d e r s may need the assistance of beneficial trade policies. Y o u
+m ay choose to grant trade subsidies using the Diplomacy screen. For more
+information see the “Trade Policies” section, starting on page 78. 
+When your Great Power grants a trade subsidy to another country, the price of
+commodities traded between the two countries changes by the percentage amount
+of the subsidy. This fav o u rs the other country on both ends of trade deals with
+you. When your Great P ower buys from that countr y, prices are higher, and when
+your Great Power sells to them, prices are lower.
+This reduction of your pr o fits usually pays for itself in the long run. Since ot h e r
+c o u n t r ies often decide to offer their products to the countries that pay them t h e
+m o st, your tr a d e r s enjoy an adv a n ta g e over all other bidders for the r e s o u rc e s
+grown or mined by that country. Your com p et i to r s are the r u l e rs of the ot h e r
+G reat Pow e rs, not the Minor Nations. Off e ring subsidies to the Minor N a t i o n s
+g i ves your Great Power an adv a n ta g e over the com p etition, in re t u rn for a
+marginal (and often temporary) reduction in profits.
+Effects of Diplomacy on T rade.
+Subsidised prices and im p roved diplomatic relations both affect the order in which
+c o u n t r ies re c e i v e off e rs to buy commodities. Countries with commodities to sell
+combine both f a c to r s to decide which country is the most fav o u red trading par t n e r.IMPERIALISM: Trade 63
+Barbed Wire. Barbed wire enclosed the open range and allo wed farmers to regulate their herds and
+improve their breeds.
+--- page 68 ---
+You im p rove diplomatic relations using the D i p l o m a c y s c reen. For det a i l e d
+i n st r uctions, see the “F o reign Aid and Br i b e ry” section, st a rting on page 77. But
+t rade affects diplomacy, too. Each time your Great Power com p l etes a deal with
+a n other country where you have established a trade consulate or an Embassy, t h e
+relationship with that country im p roves slightly. By choosing a few nations to be
+regular trading par t n e rs, you can focus the effects of your diplomacy and tr a d e .
+Your diplomacy gets your trading off to a f a st sta rt; trade causes relations to
+improve more quickly, giving you more options in diplomacy.
+Information in Screen Border .
+The wooden bor d e rs of the Bid and Off e rss c reen display icons r e p re s e n t i n g
+commodities that the indus t rial w o rke rs need. The most im p o rtant is the canned
+food icon. When this appears, it means that your w o rke rs, th re a t ened by sickness
+or starvation, demand that the traders obtain some food from abroad. 
+The appearance of o ther commodity icons tells you that you are in short supply of
+that commodity; that is, the capacity of the f a c to r y or mill that r e qu i r es th a t
+commodity for production e xceeds the warehouse s tockpile, and the amount being
+transported to industry within your Empire.
+Example: Using Border Information on the “Bid and Of fers” Screen.
+If the indus t rial capacity of your steel mill is “1 6 ,” for ex a mple, and you have set
+your Tra n s p o r ts c reen slider to tr a n s p o r t four units of iron, and your w a re h o u s e
+c o n t ains ten units of iron; then an iron icon appears in the Bid and Off e rss c re e n
+b o rd e r , to show you that your steel mill can use two more units of iron this tur n .
+This might be a good reason to enter a bid on iron.
+Giving T rade Orders.
+Your tr a d e r s need not be told what to do ev e ry turn. Once you have est a b l i s h e d
+your or d e rs, you visit the Bid and Off e rss c reen only to c h a n g e them. Of cour s e ,
+if cir c u m s tances c h a n g e, you might decide to visit the Bid and Off e rss c reen to
+consider your new needs.
+A buy bid ins t ructs your tr a d e r s to consider all available off e rs of the r e qu e s te d
+c o m m o d i t y . A sell offer includes inf o rmation from you about the maximum amount
+you wish to sell. Your tr a d e r s continue to offer the commodity to bidders until t h e
+amount you select is sold or until all bidders have r e j e c t ed the remaining amount.
+Sliding brass bars are used to mark your buy bids and sell off e rs. To enter a bid,
+click on the brass loop immediately to the left of the appropriate commodity icon.
+The Bid Bar for that commodity slides out of the wood. Enter sell off e rs using t h e
+other bar and loop to the right of the Bid Bar . When the O ffer Bar slides out, a slider
+and a sell quantity number appear in the Quantity to Of f e rcolumn. Using the arrows
+to the right and left of this slider you increase or decrease the amount of t h e
+commodity to offer.IMPERIALISM: Trade 64
+CONTENTS
+--- page 69 ---
+Deciding What to Bid On.
+The economy of IMPERIALISM recreates the age when mer chants and industrialists
+of Great Pow e rs ga rn e r ed huge pr o fits by obtaining raw r e s o u r ces from abroad at
+l ow cost, and selling products manuf a c t u r ed from the r e s o u r ces back to the same
+people who grew or mined the original r e s o u r ces. Often the influx of c h e a p
+m a n u fa c t u r ed goods from abroad would des t roy the market for local pr o d u c t i o n
+of the Minor Nation, guar a n teeing the Great Power a market for its goods.
+S o m e times Great Pow e rs qu i te int e n t i o n a l l y discour a ged local production to
+increase the profits of their own industries.
+As ruler of a Great Pow e r, you t a ke adv a n ta g e of such opportunities. Enter bids
+on re s o u r ces such as coal, iron, co t ton, and timber. Great Pow e rs ge n e ra l l y avo i d
+selling these commodities, so your trading partners are Minor Nations for the mos t
+part. On the o ther hand, if you enter bids on materials such as s teel, or goods suc h
+as har d wa r e, the cash you pay for these commodities helps your opponents, t h e
+other Great Powers. 
+Limits on Bidding.
+You may bid on only four commodities each turn. 
+Deciding What to Of fer for Sale.
+Your challenge in of fering items for sale lies in balancing the internal needs of your
+G reat Power with the need for immediate pr o fits from trade. Clothing and
+f u rn i t u r e, for ex a mple, may be sold on the w o rld market for substantial g a i n s .
+However, encouraging mig ration and increasing the number of industrial wor kers
+requires the expenditure of clothing and furniture in the capital building.
+For the most part, price levels cr e a te a situation where the most eff i c i e n t
+commodities to sell are the four goods: clothing, fur n i t u r e, har d wa r e, and
+armaments. Ho wever, if demand for materials such as s teel or lumber pushes their
+p rices high enough, it can become more efficient to sell these commodities. The
+G reat Pow e rs that purchase your mat e rials can use them for indus t rial or milit a ry
+expansion. Most goods go to the Minor Nations, not your competition.
+Limits on Of fering.
+You may offer for sale as many diff e rent commodities as you hold in y o u r
+wa rehouse stockpile, unused by indus t ry this turn. Howev e r, the quantity of each
+commodity off e re d c a n n o t exceed the total merchant marine number of y o u r
+G reat Pow e r. For more inf o rmation see the “Merchant Marine” section, t h a t
+fo l l ows. This number appears in the right border of the screen under n e a t h th e
+ship icon.IMPERIALISM: Trade 65
+--- page 70 ---
+Merchant Marine.
+The merchant marine number r e p resents the total cargo holds available in all t h e
+m e rchant ships owned by your Great Pow e r. Each cargo hold can carry one unit
+of any trading commodity. The total merchant marine number establishes t h e
+maximum amount you can offer for sale of any one item. A more significant limit
+on trading, under most circums tances, is the fact that each cargo hold can be used
+only once per turn. 
+Examples: Limits of Mer chant Marine.
+E ven though you can offer four units of clothing and four units of fur n i t u r e
+because your merchant marine number is f o u r, it is unlik e ly you can sell all eight
+units because you have only a total of four cargo holds. You might sell more t h a n
+the four you can deliver if the buyer is a Great Power with its own cargo holds.
+Not only does the merchant marine number limit how much you can sell; it also
+limits the amount of commodities you can buy. If your merchant marine number
+is four and you sell four units of clothing to a Minor Nation, none of the bids y o u
+e n te r ed this turn can be filled. You can buy nothing if you have no merc h a n t
+marine to move the cargo.
+How the Mer chant Marine is Used.
+Mer chant Marine of Other Great P owers.
+No Minor Nation owns merchant marine. When you trade with a Minor N a t i o n ,
+as either buyer or seller, you can be sure that your merchant marine is r e qu i re d .
+H oweve r, since the other Great Pow e rs do own ships, your merchant marine is
+not always used when you trade with them.
+The rule for trades be t ween Great Pow e rs is that the buyer always picks up t h e
+commodities. If a bidder has no remaining cargo holds available, the bidder is not
+p e rm i t t ed to accept the deal, and the items are off e red to the next bidder on the lis t .
+Commodity Order .
+To make planning ahead with your merchant marine possible, I M P E R I A L I S M
+a l ways uses an established order when expending the Great Pow e rs’ merc h a n t
+m a rine for trade. This commodity order is shown on the Bid and Off e rss c re e n
+f rom top to bo t tom. Clothing deals, for ex a mple, are always considered prior to
+all other deals because clothing is the f i rst item in commodity or d e r. Re s e rv i n g
+some cargo holds for later deals becomes an impor tant skill. For more information,
+see the “Merchant Marine and Commodity Order” section, starting on page 69.IMPERIALISM: Trade 66
+CONTENTS
+--- page 71 ---
+Mer chant Marine in War .
+Interceptions.
+Once your Great Power declares w a r, or is att a c ked by another Great Pow e r, yo u r
+m e rchant marine can be int e rc e p ted, and sunk or des t royed. Of course, you can do
+the same to your enemies. You r e c e i v e not i fications of both successful int e rc e pt i o n
+of enemies’ merchants, and losses among your own in the battle r e p o rt .
+Escorts.
+To reduce the potential for losses among your merchant marine, w a rship escor t s
+m ay be assigned. Any ship docked at your capital and fully r e p a i r ed is used to
+escort merchants during that turn.
+Receiving T rade Of fers.
+Accepting/Rejecting Of fers.
+Once all Great Pow e rs end their turns, the w o rld market opens. You now r e c e i v e
+offers from countries selling the commodities you bid on using the Bid and Of fers
+s c reen. You must accept or reject each offer as it is pr e s e n t ed; though you are fr e e
+to ch a n g e the quantity to accept any lower amount. By placing your cursor ov e r
+the picture of the commodity on the offer sheet you can see hot text in the upper-
+right which tells you the amount of that commodity in your warehouse.
+A fter you (the potential buyer) act on each off e r, any commodities remaining are
+passed on to o ther countries that bid on those commodities. Of course, you might
+n ot be the f i rst buyer in line. The off e rs you see may already have been passed up
+by other countries acting ahead of you.IMPERIALISM: Trade 67
+CONTENTS
+Treasur y
+Reject This Of fer Accept This Of fer Remaining Mer chant MarineView Mar ket TabsHelp & InformationBriefingClick here for T rade
+Minis ter's Briefing
+Commodity Of fered
+Offering Nation
+Price
+Amount Of fered
+Click here to mak e
+this the Final Of fer
+for the Type of 
+Commodity
+--- page 72 ---
+As each offer is pr e s e n t ed, you can accept any number up to the amount off e re d .
+C h a n g e the number in the box and then click on the accept seal shown on t h e
+offer sheet. To reject a deal, click on the reject seal. 
+If you decide that you have purchased enough of a certain commodity, check t h e
+box “no more of fers of...(that commodity).” You are presented with no more deals
+for that commodity this turn.
+Information: The T rade Book .
+The offer sheet itself appears on the left side of the screen. It provides sim p l e
+i n fo r mation on each particular off e r. By clicking on the small tabs on the book to
+the right of the screen, you obtain more information about the world market.
+Each tab supplies de tails on the world mar ket in that commodity. When the tab is
+s e l e c t ed, the Trade Book opens to a tw o - p a g e display. The left page lists t h e
+c o u n t r ies off e ring to sell a commodity, the quantity off e red, and the r a n ked or d e r
+of all bidders. For ex a mple, the f i rst flag shown under the name of an off e ri n g
+country is the flag of the bidder who acts on that of fer fir st. On the right page is a
+l i st of bidding countries with the amount of merchant marine curr e n t ly ava i l a b l e .
+A country with no merchant marine (if a Great Power) cannot accept any deals
+regardless of its position in line.
+Mar ket Presence or Absence.
+You cannot r eview mar kets unless you ha ve entered a bid on that commodity. Your
+t ra d e r s do not have enough time to re v i ew the markets of commodities that t h ey
+cannot purchase.IMPERIALISM: Trade 68
+Go to Deal BookCurrent T reasur y
+National Mer chant
+Capacity
+Tab to Select Mar ket
+to Vie w
+List of Countries
+Bidding for WoolCurrent Le vel of Mer chant Shipping
+List  of Countries
+Offering Wool
+Flags Show Orders of 
+Trading Partner
+Preference
+--- page 73 ---
+Mer chant Marine and Commodity Order .
+A basic component of trade is the careful use of your merchant marine each tur n .
+For ex a mple, on a turn when you plan to sell stockpiled har d wa r e, consider
+c a re f u l l y what items you can accept with the remaining cargo capacity once t h e
+n e c e s s a r y amount is used for har d wa r e. On a turn when you have v e ry little to
+sell, bid on canned food or other items that you nor m a l l y would not have ships
+available to move. 
+O ffe rs always occur in the same or d e r, the commodity order shown on the B i d
+and Off e rss c reen, and in the tabs on the side of the trade book. This means, f o r
+exa mple, that if you desper a te ly need iron, you may need to stop accepting all t h e
+wool you can get in order to r e s e rve some of your limited merchant mar i n e
+capacity for the iron coming later.
+For ex a mple, click on the Trade Book’s i ron tab to look at the market in iron. If
+one of the countries selling iron shows your f lag as its top bidder, you can count
+on receiving an iron offer this turn. Save some merchant marine for it.
+The Deal Book .
+At the end of e very trade of fers phase, before the new turn begins, the Deal Book
+is displayed. It opens to the page showing a summary of all of your trades. Y o u
+may need to turn se veral pages to see all the deals you ha ve concluded. If you want
+to look at the Deal Book during your turn, it can be brought up through the Help
+and Inf o rm a t i o n dialog, for more inf o rmation see the “Help and Inf o rm a t i o n
+Dialog” section, starting on page 9. 
+The Deal Book l i sts all your countr y ’s trades, as well as potential deals that w e re
+not made because you rejected them or ran out of merchant marine.IMPERIALISM: Trade 69
+Sales & ProfitsCurrent T reasur y
+Help & Information
+Click Corner t o
+View N ext Pag ePurchase & o ther Of fersTrade Book Tabs
+--- page 74 ---
+Summary of T rading & Overseas Profits.
+One page on the Deal Book includes a summary of all your trades. Ev e n t u a l l y,
+your o verseas profits add to the positive side on this balance sheet. Overseas profits
+a re any money you make when another country sells something or mines some
+gold or gems. The only way to earn this beneficial bonus is by purchasing land in
+a Minor Nation with a De veloper and then increasing production of the land wit h
+your other civilian units. For more on how to do this see the “W o rking In Ot h e r
+Nations” section, starting on page 29. 
+Your Great Power also incurs c h a rges for milit a ry upkeep. As your armies and
+navies expand and modernise, you must pay more each turn.
+Your Great P ower’s Credit.
+S o m e times you may spend too much money and end a trade off e rs phase in t h e
+red. The Deal Book tells you this, and lists your borrowing limit. If you go over t h i s
+limit, you r e c e i v e a w a rning about a f o rced sale of your w a rehouse stockpile. The
+p rices paid during a f o rced sale are q u i te low, and it is a good idea to avoid it if y o u
+can. Also, you cannot make purchases nor can you give or d e rs that r e qu i r e an
+ex p e n d i t u r e during your turn, as long as your debt exceeds your limit.
+On the other hand, t h e re is nothing wrong with borrowing as long as you stay
+within one-half of your credit limit. If you go o ver one-half the maximum allo wed
+your interest rate s tarts to worsen until the money is paid back. On the o ther hand,
+since the world banking community likes to ha ve countries in debt, e very time you
+re p ay the money you have borrowed, the int e re st ra te for future loans im p rove s .
+Your credit limit also increases as your national income rises.IMPERIALISM: Trade 70
+Heavy Artiller y.The in vention of a recuperator to reduce recoil and the de velopment of an all-s teel
+cannon led to massive new artillery pieces.
+--- page 75 ---
+DIPLOMACY
+What is Diplomacy?
+Diplomacy provides a s t ru c t u r e for your int e raction with the other countries in
+the w o rld. Also, the D i p l o m a c y s c reen provides useful inf o rmation for plo t t i n g
+your ov e rall st ra te g y . As with other activities in I M P E R I A L I S M , the or d e rs you give
+in diplomacy are carried out simult a n e o u s l y with other Great Pow e rs’ ord e rs at
+the end of the turn. Until you click the End T u rnb u t ton you can t a ke back any
+diplomatic orders you give.
+T h e r e are t h ree ways to im p rove your relations with another country: establish a
+non-agg ression pact, g rant foreign aid,and conduct trade. You won ’t see the colour
+code showing the relationship c h a n g e eve ry time you t a ke an action. The benef i t s
+of diplomatic actions build up over time; although t h ey are gradual, t h ey are
+essential to success.
+The q u i c ke s t way to im p rove relations is f i rst to build a trade consulate, and t h e n
+to trade fr e qu e n t l y with the nation you are courting. Use trade subsidies to secure
+your status as most-favoured trade partner.
+Going to the Diplomacy Screen.
+From the Te rrain Map s c reen t o o l b a r , click on the Go to Diplomacy b u t to n
+w i th the diplomat’s hat on it. This button appears in a lighter colour each
+turn, until you have visited the Diplomacy screen during that turn.
+Using the Diplomacy Screen for Information.
+The two tabs on the left side of the D i p l o m a c y s c reen are used to obt a i n
+i n fo r mation on all the countries of the w o rld. N e i ther of these tabs provides an
+i n te r face for giving diplomatic commands. Whenever you enter the D i p l o m a c y
+screen, the information tab is selected.IMPERIALISM: Diplomacy 71
+CONTENTS
+Return to Ter rain MapCurrent T reasur y Jump to Orders Screens
+Help & Information
+Diplomatic Overtures Tabs
+Grants Tab
+Trade Policies TabInformation Tab
+Council Report Tab
+--- page 76 ---
+Information Tab.
+Your own country is selected when you f i rst open the D i p l o m a c y s c re e n .
+You see some facts about your milit a ry and indus t rial st re n g t h as well as
+the size of your Empire, e xcluding colonies. Clicking on a dif ferent countr y
+on the map selects the new country.
+By selecting the various Great P owers you r eview their size as well as military and
+i n d u st r ial st re n g t hs. If you select a Minor Nation, the inf o rmation is slightly
+d i ffe rent and includes a listing of the fav o u ri t e trading partner and the Gr e a t
+Power with the best diplomatic relationship with the Minor Nation. These two
+m ay be diff e rent due to the effect of trade price subsidies. The fav o u ri t e tra d i n g
+p a rtner r e c e i v es the f i rst chance to sell to and buy from the Minor Nation, while
+the Great P ower with the best relations is closest to gaining the Minor Nation as a
+colony.
+This inf o rmation about each country is called basic inf o rmation. To obtain more
+details, you use the centre icons in the middle of the lower part of the screen.
+Using the “Centre” Icons.
+In the middle of the screen, t h ree additional icons provide more
+i n fo r mation on any of the countries in the game. To re t u rn to the basic
+i n fo r mation display, click on the blue “ i” . R e ga r dless of which centre icon y o u
+select, you can always cycle t h rough all the countries in the game by clicking on
+them on the map.
+Treaty S tatus.
+The treaty status icon appears as a small scroll. Click here to see a map
+d i s p l a y of the v a rious treaties and w a rs of any nation in the game. It can
+be useful to see which Great Pow e rs are allied with one another or to see which
+Minor Nations have joined larger empires as colonies. 
+Relationships.
+The small r e c tangular document (which r e p resents a grant of f o reign aid)
+b rings up the relationship display for any country in the game. U n l i ke th e
+t reaties display, the relationships shown do not im p ly any f o rmal status be t we e n
+two countries. Ins tead you are viewing the relative le vels of friendliness. Of course,
+a particular treaty s tatus might lead to more or less friendly relations. For ins tance,
+you would usually see a correlation be t ween hostile feelings and the f o rmal st a t u s
+of war on the treaty display.
+Trade Policies.
+The ship icon allows you to view the trade policies of any country. In t h e
+l ower portion of the screen is a list of the top e x p o r ts of the country. Use
+this listing to decide which Minor Nations to invade or to court diplomatically.
+On the map you see the e x i stence of any trade subsidies or boy c otts be t ween two
+c o u n t r ies. Both boy c otts and subsidies are initiated by Great Pow e rs. A subsidy
+means that the Great Power is paying more than market price for the tr a d e
+commodities of the other country, as well as selling its own commodities at low e r
+c o st to the other country. A boy c ott means that no trade of any kind occurs
+between the two countries.IMPERIALISM: Diplomacy 72
+--- page 77 ---
+Who is Winning: Council Report.
+Once the Council of Go vernors meets for the fir st time, you may r eview the v oting
+results of the last council meeting by clicking on the lower left tab on t h e
+D i p l o m a c y s c reen. The map portion of the screen shows flags in each pro v i n c e
+that voted at the last meeting, and the lower portion of the screen shows you t h e
+vote totals of the two nominated Great P owers. For more on the Council see “Ho w
+to Win” on page 15.
+Diplomatic Overtures.
+On the right side of the lower portion of the D i p l o m a c y s c reen are t h re e
+tabs that allow dif ferent sorts of diplomatic initiatives. Clicking on the fir st
+of these, the large tab with the scroll, allows you to make diplomatic
+overtures to the other countries in the game.
+How to Make an Overture.
+The ov e rt u r es map always displays the treaty status of your own country. To view
+i n fo r mation on treaties be t ween other countries you must use the inf o rmation tab.  A
+n ew ov e rt u r e tow a rd any country may be made by clicking f i rst on the desired scr o l l
+on the lower portion of the screen, and then clicking on the country on the map. 
+When you click on the scroll, your cursor changes to represent the type of o vertur e
+you are making. When you click on the countr y, an icon s tays behind to mark that
+you made the overture. 
+To cancel the o verture before the end of the turn, click on the icon on the countr y.
+It disappears conf i rming that you have rescinded that ov e rt u r e. If the ov e rt u r e
+costs mone y, the amount you spent is r eturned to your treasury upon cancellation.
+War and Peace.
+At the beginning of the game, your Great Power is at peace with ev e ryone. The
+ove rt u r e of a declaration of war may be made to any Great Power or Minor
+Nation. Once you are at war with a countr y, the peace o verture becomes a vailable.
+Unlike most o vertures, a country cannot refuse a declaration of war. If you declar e
+war on a country, it r e c e i v es no t i fication of the war as soon as you click the E n d
+Turnbutton, and the war begins on the next turn. You must declare war in order t o
+conduct any type of hostile action on land or sea. Ob v i o u s l y, war w o rsens t h e
+relations between your country and those with whom you are at war.
+Less ob v i o u s l y, whenever you declare w a r, your relations with all countries in t h e
+game can change significantl y. Countries that dislike the country you attacked ar e
+m o re fri e n d l y tow a rd you after you declare w a r. Countries with good r e l a t i o n s
+with your victim dislike you more after you declare war. IMPERIALISM: Diplomacy 73
+CONTENTS
+--- page 78 ---
+It is wise to t a ke this fallout into account when deciding what Minor Nation to
+a t ta c k . All Minor Nations like their neighbouring Minor Nations and believe t h a t
+their own f a te is tied to the f a te of their neighbours. You should aim your w a r
+machine at Minor Nations distant from those you trade with every turn.
+Minor Nations never refuse an offer of peace. They are always happy to have a
+G reat Power stop attacking them. Great Pow e rs, on the other hand, accept peace
+o ffe rs only when it is to their adv a n ta g e to do so. Gener a l ly, if t h ey have obt a i n e d
+what t h ey wa n ted and are not able to t a ke your capital at this time, t h ey accept
+your peace overtures.
+Diplomatic Overtures to Minor Nations.
+At the beginning of the game, the diplomatic ov e rt u r es it is possible to make to
+Minor Nations are limited. A declaration of war is always available, but more
+c o mp l e x relationships must be built over time. Sometimes one successful ov e rt u r e
+is re qu i r ed bef o re another one can be att e mpted. At the beginning of the g a m e ,
+your f i rst step is to establish trade consulates in some of the Minor Nations. Lat e r
+you may establish Embassies, offer non-aggression pacts, and att e mpt to con v i n c e
+Minor Nations to join your Empire.IMPERIALISM: Diplomacy 74
+Paddle wheels. Paddle wheels pr ovide adequate po wer but the huge wheels take space which cannot be
+used for mounting cannon on the broadside.
+--- page 79 ---
+Trade Consulates.
+Minor Nations always accept an ov e rt u r e to establish a trade consulate. The ov e rt u r e
+c o sts you $500 and the new consulate opens st a rting the turn after you make t h e
+ove rt u r e. The most immediate benefit of a new consulate is the right to set tr a d e
+policies tow a rd that Minor Nation, policies such as subsidies to encour a ge tra d e .
+Trade policies are set using the tab with the ship icon on the right side of the screen. 
+Once a new trade consulate is established in a nation, each com p l eted trade deal
+b et w een your Em p i re and this nation im p roves your diplomatic relationship. If
+relations im p rove enough, some of the council votes of the other nation might go
+to you. Ev e n t u a l l y, their leaders could decide to join your Em p i re peacefully as a
+colony provided you build an Embassy. 
+A trade consulate is required for the later construction of an Embassy. 
+Embassies.
+Once you establish a trade consulate in a Minor Nation, you are able to est a b l i s h
+an Embassy in the Minor Nation as well. The Embassy ov e rt u r e costs $5000; at
+the beginning of the game, you need to be restrained in your of fers. Minor Nations
+never refuse your request to establish an Embassy.
+Embassies permit full-fledged diplomatic relations including g rants of foreign aid,
+pacts and other treaties, and the possibility of armed int e rvention if the Minor
+Nation is invaded. Until you establish an Embassy, your civilian w o rke rs may not
+enter the Minor Nation. Because Embassies are so expensive, you should generall y
+establish Embassies only in Minor Nations where your intentions are peaceful. 
+Only Minor Nations where you ha ve Embassies e ver join your Empire voluntaril y.IMPERIALISM: Diplomacy 75
+Marine Engineering. Armoured Cruisers used new s team turbine engines to vastly increase the speed
+of war fare at sea.
+--- page 80 ---
+Non-Aggression Pacts.
+Once you have established an Embassy, you are able to offer a pact ov e rt u r e to
+the Minor Nation. This action costs no cash and it’s a good idea to offer the pact
+to all Minor Nations where you es tablish Embassies. Minor Nations alw ays accep t
+an of fered non-agg ression pact, since it limits the actions of Great P owers. In fact,
+th ey are so happy to r e c e i v e a pact that it signif i c a n t l y im p roves your Gr e a t
+Power’s relationship with the Minor Nation.
+A non-aggression pact hurts you only if you break it. If this happens, the nor m a l
+wo rsening of your relationships across the w o rld is signif i c a n t l y increased. Ot h e r
+countries believe you can no longer be trusted.
+Joining the Empire.
+The Em p i re scroll on the diplomatic ov e rt u r es screen allows you to ask a Minor
+Nation to join your Empire voluntaril y. This o verture costs no thing, but the Minor
+Nation declines it if your relations are not suff i c i e n t l y fri e n d l y. Using t h e
+i n fo r mation tab you can look at your relationships w o rldwide. If your r e l a t i o n s
+with any Minor Nations ha ve impr oved to a dark g reen colour, an o verture to join
+your Empire might be accepted by that nation.
+When a Minor Nation joins your Em p i re vo l u n ta ri l y it is called a colony. Y o u
+c o n t r ol all the regiments owned by the Minor Nation, and you can r e i n fo r ce th e
+c o l o n y with your own f o rces. You always have pr i o rity over all other countries f o r
+the purchase of the colon y ’s commodities, and the votes of the colon y ’s pro v i n c e s
+go to you if you are nominated for victory.
+Un l i ke te rri to ry you conq u e r, the colony still retains a modicum of independence.
+It produces and purchases commodities on its own, for instance, providing a
+g u a ra n t eed market for your goods. In a colony you must purchase lands f o r
+development with a De veloper civilian unit; whereas with conquered ter ritory this
+is unnecessary.
+Diplomatic Overtures to Great P owers.
+At the beginning of the game, your Great Power already has embassies, which
+include trade consulates, in ev e ry Great Pow e r. These embassies permit full-
+fledged diplomacy with all o ther Great P owers right from the s tart of the game. If
+you fight a war, it is necessary to re-establish your embassies when peace is made.
+Alliances.
+You can offer an alliance only to Great Pow e rs. An alliance, if agreed t o ,
+e stablishes a promise of mutual defence if either ally is att a c ked by a t h i rd Gr e a t
+Powe r. When your ally is att a c ked, you r e c e i v e notice of the declaration of w a r
+and an immediate demand by the ally that you declare war on the aggr e s s o r . If
+you are att a c ked, your allies, if any, r e c e i v e notices of demand for a declaration of
+wa r. The alliance is immediat e ly bro ken when a Great Power refuses to support
+an att a c ked ally. The refusing ally suff e rs sev e re penalties in w o rld opinion
+resulting in across-the-board worsening of relations.IMPERIALISM: Diplomacy 76
+--- page 81 ---
+A similar notice is delivered to you if your ally is the agg ressor against a third Great
+Powe r. The consequences of a refusal to join this war are q u i te diff e rent. R e f u s a l
+to join a war when the ally is the aggressor does not result in any penalties. Allies
+m u st re c e i v e an offer to join the w a r, but cannot be held responsible for t h e
+judgment errors of other Great Powers.
+G reat Pow e rs offer and accept alliances based on the milit a ry conditions of t h e
+oth e rs. Great Pow e rs in a position of disadv a n ta g e are both more lik e ly to off e r
+and to accept an alliance. Choose your allies carefully.
+Joining the Empire.
+You can ask Great P owers to join your Empire. They ag ree only if their position in
+the game is hopeless due to your success. Agreeing to such an offer r e m oves t h a t
+power from the game. Accepting such an o verture from ano ther Great P ower ends
+the game for a human player as well; you should decline it if you wish to k e e p
+playing.
+Foreign Aid and Briber y.
+The second tab on the right side of the D i p l o m a c y s c reen allows you to
+grant money to any country in the game where you have an Embassy. This
+cash gift dir e c t ly im p roves the diplomatic relations be t ween the countr i e s .
+For the most part, you want to grant funds to Minor Nations, not Great Pow e rs ,
+since t h e re is little chance that good relations with other Great Pow e rs — y o u r
+c o mp e tition — can help you win the game. Im p roving relations with Minor N a t i o n s
+can put you ahead in the race to grab colonies bef o re the other Great Pow e rs .
+How to Grant Mone y.
+The grants map always displays the relationships of your own country. To view
+i n fo r mation on relationships be t ween two other countries, you must use t h e
+i n fo r mation tab. A new grant tow a rd any country may be made by clicking f i rst
+on the desired grant amount on the lower portion of the screen and then clicking
+on the country on the map. 
+When you click on the g rant certificate, your cursor changes to represent the g rant
+you are making. When you click on the country, an icon stays behind mar k i n g
+that you made the grant. 
+To cancel the g rant before the end of the turn, click on the icon on the countr y. It
+d i s a p p e a r s to show that you have rescinded that grant. The amount you spent is
+returned to your treasury upon cancellation.
+Locked Grants.
+L o c k ed grants function just like normal grants ex c e pt that t h ey continue ev e ry
+t u rn with no further order from you. The cumulative effect of ten $1000 grants is
+greater than one $10,000 g rant, so locked g rants are a good idea if you can af ford
+the regular drain from your cash, and you are not in a hurry to see results.IMPERIALISM: Diplomacy 77
+CONTENTS
+--- page 82 ---
+Assessing Success of Grants Policy .
+The nine relationship levels are colour-coded, but an immediate c h a n g e in colour
+does not occur with each grant. Remember which Minor Nations are r e c e i v i n g
+your funds and w a t ch for them during the trade off e rs each turn. If you see y o u r
+position in the line of bidders for that Minor N a t i o n ’s products moving up, y o u
+k n ow that your grants are having an effect on the r e l a t i v e relationships be t we e n
+the Minor Nation and all the Great Powers.
+You should use the inf o rmation tab (grants icon display) to keep an eye on all t h e
+relationships of this Minor Nation. Select the Minor Nation and see if any ot h e r
+G reat Pow e rs have a colour as fr i e n d l y as y o u rs. See who is listed as the most
+favo u red trading partner and who is listed as having the best relations. As y o u
+grant mone y, you should be able to see your country in these sections of the displa y
+unless other Great Powers are granting as much or more than you are.
+Trade Policies.
+The third and lo west tab on the right side of the Diplomacy screen enables
+you to set trade policies with any country in the game where you have a
+t rade consulate or Embassy. While these policies cannot dir e c t ly im p rove
+relations, t h ey can encour a ge trade with the other country, t h e re b y im p rov i n g
+relations with each successful trade deal. For the most part, you grant tr a d e
+subsidies to Minor Nations. Trade subsidies with Minor Nations can put y o u
+ahead of the o ther Great P owers in the race to g rab colonies and immediately help
+you acquire needed resources through trade.IMPERIALISM: Diplomacy 78
+CONTENTS
+Breechloading Rifles. Loading a rifle at the breech ins tead of the muzzle permits more rapid firing,
+while a rifled gun bar rel increases accuracy and range.
+--- page 83 ---
+Making a T rade Policy .
+The map always displays the trade policies of your own country. To view
+i n fo r mation on the trade policies of other countries you must use the inf o rm a t i o n
+tab. A new trade subsidy of v a rying per c e n ta g es, or boy c ott tow a rd any country,
+m ay be made by clicking f i rst on one of the symbols on the lower portion of t h e
+screen, and then clicking on the country on the map. 
+When you click on the symbol, your cursor c h a n g es to r e p resent the type of tr a d e
+policy you are setting. When you click on the country, an icon stays behind
+marking that you made the new policy. 
+To cancel the policy c h a n g e bef o re the end of the turn, click on the icon on t h e
+country. It disappears confirming that you have cancelled that change.
+Subsidies.
+Subsidies have two immediate price effects, both to the adv a n ta g e of the country
+that r e c e i v es the subsidy. When the recipient country buys from the Great Pow e r
+that gr a n ted the subsidy, its prices are reduced from the current w o rld prices by
+the percentage of the subsidy. When the recipient country sells to the Great P ower
+that gr a n ted the subsidy it sells at higher prices, increased from the current w o rl d
+price by the percentage of the subsidy.
+A Great Power should never grant a subsidy to make more money in the short
+run. Howev e r, when com p eting for a market with other Great Pow e rs, you might
+find it to your adv a n ta g e to sell at reduced prices if the alt e rn a t i v e is not to sell at
+all. When competing with o ther Great P owers for scarce resources, you might find
+it better to pay more if the alternative is not getting the resources at all.
+In the long run, subsidies establish a dependence of the Minor Nation on y o u r
+G reat Pow e r. Each deal that you make with the Minor Nation moves you furt h e r
+ahead of the other Great Pow e rs. Ev e n t u a l l y, your status as the fav o u ri t e tra d i n g
+p a rtner allows you to control the f o reign trade of the Minor Nation. When t h e
+nation becomes your colony, you can set prices at the w o rld market level and buy
+and sell all you want.
+Boycotts.
+A trade boy c ott goes into effect aut o m a t i c a l l y bet ween countries at w a r. If y o u
+choose to enter other boy c otts, it has the obvious effect. You r e c e i v e fewer tr a d e
+o ffe rs and have fewer potential markets for your goods. The boy c ott button with
+the red “X” t h rough the ship r e p resents a boy c ott preventing your own Gr e a t
+Power from trading with the country you click on.
+Colony Bo ycotts.
+Once you own a colony, you may order it to boy c ott countries independently of
+your Great P ower. Ho wever, all your colonies must share the same bo ycott policies.
+Click on the boy c ott button with the black cross, and then on the country y o u
+want your colony or colonies to bo ycott. If you bo ycott the same country with your
+Great Power, you see a combined red “X” and black cross boycott indicator. IMPERIALISM: Diplomacy 79
+--- page 84 ---
+Receiving a Diplomatic Of fer.
+Diplomatic of fers are a result of o vertures taken by ano ther Great P ower, including
+the declaration of war ov e rt u r e. On the Diplomatic Off e rss c reen, you must
+choose to accept or reject each offer as pr e s e n t ed. Actions and f a i l u r e to act have
+consequences, such as declaration of war and worsening of diplomatic relations.
+Offer to Join an Ally on the Attack .
+When an ally att a c ks another Great Power and asks you to join, refusal has no
+penalties e xcept for the loss of the alliance. Join the war if you want to fight a war ;
+otherwise, stay out.
+Demand for You to Defend an All y.
+You must be cautious in declining these demands. Since your ally is under att a c k,
+th e re are substantial penalties for refusal. Of course, when you accept, nor m a l
+declaration of war penalties are paid, dampening your relations with the countries
+friendly to the Great P ower you declare war on. Ho wever, the penalties for refusal
+are more significant in most cases. 
+Re p e a te d l y breaking alliances ev e n t u a l l y leads to diplomatic isolation. The only
+way to win the game if this happens to your Great Power is conq u e st and milit a ry
+dominance of all the other Great Powers. IMPERIALISM: Diplomacy 80
+CONTENTS
+Oil Drilling. Oil was drilled for the fir st time at Titusville, Pennsy lvania, in 1859. Six years later the
+first oil pipeline, six miles long, was constructed.
+--- page 85 ---
+Offer to Make Peace.
+If you accept this off e r, the war ends be t ween your country and the Great Pow e r
+that made the off e r. Since your allies have not necessar i ly re c e i v ed the same off e r,
+you may end up breaking your alliances if you agree to a peace treaty.
+Offer of an Alliance.
+When another Great Power sends an ov e rt u r e for a diplomatic alliance, it is an
+o ffer to join with them for mutual defence. It is true that an alliance is basically
+defensive, although it has offensive implications.
+If you agree to the alliance, you are making a public promise to defend the ot h e r
+G reat Power if it is att a c ked by a t h i rd Great Pow e r. You are accepting t h e i r
+promise to do the same for you.
+Your relations are not adjusted do w nwa rd if you refuse the off e r. You should
+p ro b a b l y refuse if y o u’re not par t i c u l a r ly int e re sted in having a war and the ot h e r
+c o u n t r y seems more t h re a t ened than you are. This is q u i te like ly the case when
+they ask for an alliance; threat is what makes them seek an alliance.
+On the other hand, if you feel t h re a t ened, an alliance may dissuade a pot e n t i a l l y
+h o stile power from attacking you. N o rm a l l y, most countries do not attack if t h e
+military balance is not in their favour.
+Offer to Inter vene in a Minor Nation.
+An of fer to inter vene in a war on behalf of an attacked Minor Nation is a one-time
+chance with that nation. If you decline, you do not ha ve ano ther chance to absorb
+that Minor Nation as a colony, ex c e pt in the unlik e ly event that the other Gr e a t
+Power’s attack fails and the Minor Nation joins you peacefully later in the game.
+The adv a n ta g es of int e rvention are substantial. F i rst, you get the colony
+i m m e d i a te l y, or at least what’s left of it after you defend it. The provinces vote f o r
+you if your Great Power is nominated by the Council of Gov e rn o r s for vict o ry.
+H oweve r, your decision to int e rvene counts as a declaration of war ag a i n st th e
+other Great P ower and this makes you the agg ressor. Alliances of the Great P ower
+you are declaring war on may react to your declaration. IMPERIALISM: Diplomacy 81
+--- page 86 ---
+FIGHTING B ATTLES
+Battles t a ke place be t ween two turns. After all Great Pow e rs have or d e red th e
+m ovement of their troops, the movements and att a c ks ta ke place simult a n e o u s l y.
+H oweve r, when or d e rs contradict each ot h e r, such as two battles planned in t h e
+same province, one battle must be r e s o lved f i rst. The order for r e s o lving battles
+depends on the army initiative rating of the f o rces inv o lved. Not sur p ri s i n g ly, th i s
+rating depends on the r e l a t i v e make-up of the army and the e x p e r ience of t h e
+a rmy leader, if any. These rules always apply, r e ga rdless of the mode of r e s o lv i n g
+the battle.
+Example: Ar my Initiative.
+If Prussia and It a ly invade a province of Switzerland on the same turn, the two
+fo rces trying to move into the same place are com p a red. Since the Italians have
+m o re cav a l ry and a superior leader, their f o rce gains initiative over the Pr u s s i a n s .
+The battle be t ween the Swiss and the Italians is r e s o lved f i rst with the It a l i a n s
+victorious, in this example. 
+If the Prussians are allied with or at peace with It a ly, their invasion does not t a ke
+place since the province has become Italian. On the other hand, if the Pr u s s i a n s
+a re already at war with It a ly, moving second provides an adv a n ta g e. When t h ey
+a t tack the Italians, the Italians may already be w e a kened from their battle with
+the Swiss.
+Battles and Reports.
+In any turn during which you fight a battle or battles, on land or sea, the battle
+re p o r t screen appears. On this screen at the bo t tom of the page you can read t h e
+composition of the forces involved and the result.
+Click on the wooden Information button mar ked with an “ i” to see the de tails on the
+t wo armies or f l e ets that fought the battle. The f o rces for both sides are display e d ,
+with their health after the battle. 
+E l i m i n a t ed regiments are marked K I Awhile eliminated ships are marked as S U N K .
+All regiments and ships also display their experience medals, including experience
+j u st earned in that battle. For naval actions, you may also see cargo cap t u red or
+lost when merchant ships are intercepted and captured or sunk.
+Use the arrows to cycle be t ween multiple battles, or click on the map icon t h a t
+marks each battle on the world map.IMPERIALISM: Fighting Battles 82
+CONTENTS
+--- page 87 ---
+Tactical Land Battles.
+Fighting on a tactical battlefield gives you the best chance for a crushing defeat of
+your enemies. This option may be turned off using the Pr e fe rences screen at any
+time during your turn. Howev e r, once you enter the tactical battlefield, you are
+c o m m i t t ed to fighting t h e re; but you may choose to let your Defence Minist e r
+handle the battle for you.
+Deployment.
+When the battle begins, green dots displayed on the battlefield show where y o u
+can deploy your regiments. The next regiment to be deployed appears in t h e
+toolbar. You can delegate deployment to your Defence Minister.
+Individual Regiment Initiative.
+Once both sides have deployed their f o rces, the battle is fought in a sequence of
+unit moves based on the initiative rating of the individual units. This means t h a t
+s eve ral of your units might act bef o re any of the enemy regiments; or, that t h e
+e n e m y fo rces might all act bef o re you can. Gener a l ly, cav a l ry acts bef o re infa n t ry,
+and inf a n t ry acts bef o re art i l l e r y. Howev e r, these rules are modified by t h e
+experience rating of the regiments and the qualities of the leaders on each side.
+Because the order of mo vement and firing on the battlefield is based on initiative,
+th e re is no way for you to select your units out of turn. Units must act or not act
+when t h ey get the chance. Often it is useful to avoid f i ring during your tur n ,
+p re s e r ving that r e g i m e n t ’s fi re as opportunity f i re for an opponent’s move. If t h i s
+is done, the unit fires on the first enemy to move within range.IMPERIALISM: Fighting Battles 83
+CONTENTS
+National Flag
+Unit with Initiativ e T arget UnitStatus Bar
+Jump to Tar get
+End Mo ve
+Retreat
+Unit with Initiative Icon
+Target Unit Icon
+Otto-Pla y
+--- page 88 ---
+Using the Toolbar .
+The toolbar displays the active regiment and the r e g i m e n t ’s selected t a rget. N e a r
+these unit pictures you see any medals won by either of the units. These medals
+measure the regiment’s experience.
+The top button, Jump to T a rg e t has a small cross hair reticle icon on it. When
+one of your regiments is active, click on this button to cycle t h rough all
+e n e m y units in r a n ge. This reduces the amount of scrolling you need to do.
+The middle button, End Move ends the turn of an active unit. If you c h o o s e
+to reser ve you fire or to mo ve only part of your mo vement points, you need
+to click here to advance the game to the next active unit.
+The lower button, R e t re a t , ord e rs a l lof your f o rces to re t reat, not only t h e
+a c t i v e unit. You should click here only if the battle is lost and re t re a t i n g
+might save the lives of some valuable regiments.
+At the v e ry bot tom of the toolbar is a picture of your Defence Minist e r. Clicking
+h e re turns control of the battle over to your him. For more inf o rmation see t h e
+“Tactical Resolution with Otto-Play” section starting on page 87. 
+Using the Battlefield.
+On the battlefield you see an area of small pips showing the radius of pot e n t i a l
+movement of the active unit. If a pip is g reen, it means that no enemy can fire int o
+that space pr e s e n t l y and that the active unit can move their without any fear of
+immediate damage. A red pip means that enemy units can fire into that space.
+As regiments are damaged, their status bars c h a n g e from green to show red and
+ye l l ow sections. Red r e p resents actual wounded or killed soldiers. Y e l l ow
+re p resents soldiers whose morale has br o ken and who wish to flee from t h e
+battlefield.
+When a unit ’s bar is all red and/or yello w, the regiment heads off the battlefield as
+rapidly as possible. If enemies are too near, the regiment may choose to sur render .
+When one of your regiments is selected you f i re by placing the cursor over an
+e n e m y in r a n ge and clicking. You see the cursor c h a n g e to a cross hairs reticle if
+the tar get is in range, and to a red “X” o ver a r eticle if the tar get is out of range. If
+your unit has already fired, the cursor changes to an unloaded gun icon 
+You move an active regiment by clicking on a green or red pip on the battlef i e l d .
+Because the enemy can fire during your mo ve there is no w ay to take a mo ve back .
+However, you can mo ve cautiously by clicking each time a bit nearer to the enem y.
+There is no reason to move an active unit its entire distance all at once.IMPERIALISM: Fighting Battles 84
+--- page 89 ---
+An active ca valry regiment s tays active until you click done on the toolbar or until
+it has fired its weapons and used its entire mo vement. Infantry and Light Artiller y
+c a n n o t move after f i ring, but can move and then f i re. Heavy Ar t i l l e r y can eit h e r
+move or fire, but not both. 
+On the Attack .
+The best w ay to conduct an attack is concentration of force against a small number
+of def e n d e r s. Use light cav a l ry and light inf a n t ry to draw f i re from st a t i o n a r y
+d e fe n d e r s, and then move in your heavy f o rces (Heavy Inf a n t ry and Hea v y
+Cavalry are best) and destr oy the line of enemies one by one. Use your artillery t o
+weaken the better enemy defenders before your best regiments close with them.
+Defending your Provinces.
+On defence, even though you benefit from entr e n chments, you must fight activ e ly.
+Try to hit attacking ar t i l l e r y with light cav a l ry and r e s e rve your ar t i l l e r y to hit t h e
+e n e m y gre n a d i e r s and heavy cav a l ry when t h ey get close enough. Be willing to
+ret reat and save your men for a count e r- a t t ack unless you are defending your capitol. 
+Entrenchments and Forts.
+E n t re n c hments are cr e a ted aut o m a t i c a l l y by the g a rrison of a pro v i n c e .
+E n t re n c hments provide a 20% reduction in the damage the entr e n ched r e g i m e n t
+s u ffe rs. This is r e fl e c t ed on the Regiment Abilities Table by the higher def e n c e
+number for entrenched regiments. 
+C o n st r ucting f o rts with your Engineer in key provinces also provides a gr e a t
+a d va n ta g e on defence. F o rts provide even a gr e a ter reduction in damage. Each
+s u c c e s s i v e level of f o rt i f ication provides a 10% reduction over the previous lev e l .
+This means that the best f o rt provides a 50% reduction in damage according to
+this formula: 
+20%(base for entrenchment) + (10% x 3 for three fort levels) = 50% reduction.
+A ny regiments you station behind a f o rt wall but not manning the wall (adjacent
+to it) are even saf e r. These units cannot be damaged at all ex c e pt by enemy
+a rt i l l e r y. Howev e r, only your ar t i l l e r y can re t u rn fi re over the wall from t h e s e
+positions, so placing non-ar t i l l e r y units here mer e ly to protect them is a
+questionable strategy.
+E ve r y fo rt has a g a te th rough which fr i e n d l y units can sortie, ent e ring t h e
+b a t t l e f ield. These units can also re t reat from the battlefield into the f o rt using t h e
+ga te. Enemy units can never use the g a te. They must use Combat Engineers
+and/or artillery to destroy the fort.IMPERIALISM: Fighting Battles 85
+--- page 90 ---
+Combat Engineering.
+Forts can be knocked down by artillery fire, but this takes a long time. The bes t
+method is to use your Combat Engineer units to destr oy the forts. To use an
+Combat Engineer unit of any era, look for the sho vel cursor next to the position of
+the unit on the battlefield when the Combat Engineer unit is active. Clicking on a
+space adjacent to the regiment causes it to begin construction of a sapper tunnel.
+E a ch active turn for the regiment allows the e x tension of the tunnel one space
+f u rth e r. Since the regiment spends most of its time underground or behind prot e c t i v e
+c o n st r uction, it is v e ry difficult for the def e n d e r s to do serious harm to the Combat
+E n g i n e e r s while t h ey build tow a rd the walls. Howev e r, since only one tile of tunnel
+can be cons t ru c t ed each turn, it can be a lengthy process to appr o a ch the f o rt .
+Once the engineering unit r e a ches the walls, it conducts a v e ry pow e rful att a c k
+a ga i n s t one tile of the f o rt using a dynamite cur s o r. Any unit defending that tile
+can make an attack on the Combat Engineer the turn t h ey attack the wall. Once
+the fort tile is destr oyed, regiments from bo th sides can mo ve through it freely and
+the defensive bonus from that tile is eliminated.
+Leaders and Morale.
+M o s t regiments flee from battle bef o re th ey are des t royed. Generals are used to
+prevent this from occur ring. When a general is the active unit, mo ve him adjacent
+to any of your regiments who have suff e red damage, and click on your unit.
+Morale is res tored according to the ability of the General. Since this morale boos t
+restores some broken troops to action, the firepower of the regiment increases.
+Up grading a g e n e r al im p roves his movement r a te, allowing him to r e a ch more
+regiments bef o re th ey flee. The amount of morale r e sto red depends on t h e
+experience of the General, not his upgrade level.
+O ve r use of a General can cause a w e a kened regiment to be killed outright, as it
+remains on the battlefield. You should consider letting a br o ken unit re t reat if it is
+near death.
+Tactical Resolution with Otto-Pla y.
+Anytime during the battle you can instruct your Defence Minis ter to take o ver by
+clicking on his picture in the toolbar. He may not fight as well as you do, so be
+cautious using this feature.IMPERIALISM: Fighting Battles 86
+--- page 91 ---
+Regiment Abilities and Comparison.
+The table below provides ratings on the v a rious unit types. It does not r e flect all
+the adv a n ta g es that a unit of a specific cat e g o r y might enjoy. For ex a mple, all
+Light Inf a n t ry possess special adv a n ta g es in rough t e rrain on the t a c t i c a l
+battlefield.
+Regiment Abilities Table.
+•FPN.  . . . . . . . . Normal Firepower Rating. Basic attack strength of the regiment.
+•FPM.  . . . . . . . . Melee Firepower used only when the attacker is adjacent to the target.
+•RNG.  . . . . . . . R a n ge is the maximum number of tiles the unit may f i re. The number in ( ) is the r a n ge if th e
+unit is defending. This is diff e rent in the case of ar t i l l e r y, which r e c e i v es the bonus to r e fl e c t
+planned fields of fire and emplacements.
+•DEF.  . . . . . . . . This number r e flects a r e g i m e n t ’s ability to wit h stand enemy f i re. The number in ( ) r e flects a
+defence rating when the regiment is entrenched.
+•MVR.  . . . . . . . The number of tiles a regiment can move on the tactical battlefield in one initiative turn.
+•ARMS.  . . . . . . The number of armaments it t a kes to cons t ruct this unit in the ar m o u r y. This number also
+determines how dif ficult it is to deploy the unit by rail. The number of armaments you can mo ve
+by rail is limited to one for ev e ry fi ve points of tr a n s p o r t capacity. Regiments of Minut e m e n ,
+Militia, and Conscripts cannot be deployed by rail.
+Regiment T ype. FPN. FPM. RNG. DEF. MVR. ARMS.
+Minutemen  . . . . . . . . . . . . . . 5  . . . . . . . . . 5  . . . . . . . . . . 5  . . . . . . . . . 4(5) . . . . . . . . 4 . . . . . . . . . NA
+Skirmishers  . . . . . . . . . . . . . . 5  . . . . . . . . . 5  . . . . . . . . . . 5  . . . . . . . . . 7(8) . . . . . . . . 6 . . . . . . . . . 1
+Regulars  . . . . . . . . . . . . . . . . 10 . . . . . . . . . 10  . . . . . . . . . 5  . . . . . . . . . 5(6)  . . . . . . . . 4 . . . . . . . . . 1
+Grenadiers  . . . . . . . . . . . . . . 12 . . . . . . . . . 12  . . . . . . . . . 5  . . . . . . . . . 5(6) . . . . . . . . 4 . . . . . . . . . 1
+Hussars  . . . . . . . . . . . . . . . . . 7  . . . . . . . . . 10  . . . . . . . . . 3  . . . . . . . . . 7 . . . . . . . . . 11  . . . . . . . . 1
+Cuirassiers  . . . . . . . . . . . . . . . 15 . . . . . . . . . 19  . . . . . . . . . 3  . . . . . . . . . 5 . . . . . . . . . 9 . . . . . . . . . 1
+L. Artillery  . . . . . . . . . . . . . . 10 . . . . . . . . . 3  . . . . . . . . . . 9(10)  . . . . . . . 3(4) . . . . . . . . 5 . . . . . . . . . 2
+Artillery  . . . . . . . . . . . . . . . . . 16 . . . . . . . . . 4  . . . . . . . . . . 11(12)  . . . . . . 2(3) . . . . . . . . 3 . . . . . . . . . 2
+Sapper  . . . . . . . . . . . . . . . . . . 0  . . . . . . . . . 0  . . . . . . . . . . 5  . . . . . . . . . 3(4)  . . . . . . . . 4 . . . . . . . . . 2
+Militia  . . . . . . . . . . . . . . . . . . 7  . . . . . . . . . 7  . . . . . . . . . . 8  . . . . . . . . . 4(5) . . . . . . . . 4 . . . . . . . . . NA
+Sharpshooters  . . . . . . . . . . . . 10 . . . . . . . . . 10  . . . . . . . . . 8  . . . . . . . . . 7(8)  . . . . . . . . 6 . . . . . . . . . 2
+Rifle Infantry  . . . . . . . . . . . . 15 . . . . . . . . . 15  . . . . . . . . . 8  . . . . . . . . . 7(8) . . . . . . . . 4 . . . . . . . . . 2
+Guards  . . . . . . . . . . . . . . . . . . 17 . . . . . . . . . 17  . . . . . . . . . 8  . . . . . . . . . 7(8) . . . . . . . . 4 . . . . . . . . . 2
+Scouts  . . . . . . . . . . . . . . . . . . 10 . . . . . . . . . 13  . . . . . . . . . 5  . . . . . . . . . 7 . . . . . . . . . 11  . . . . . . . . 2
+Carbineers  . . . . . . . . . . . . . . . 20 . . . . . . . . . 26  . . . . . . . . . 5  . . . . . . . . . 5 . . . . . . . . . 9 . . . . . . . . . 2
+Field Artillery  . . . . . . . . . . . . 17 . . . . . . . . . 5  . . . . . . . . . . 12(13)  . . . . . . 3(4)  . . . . . . . . 6 . . . . . . . . . 4
+Siege Artillery  . . . . . . . . . . . . 30 . . . . . . . . . 8  . . . . . . . . . . 14(15)  . . . . . . 3(4)  . . . . . . . . 3 . . . . . . . . . 4
+Combat Engineer  . . . . . . . . 0  . . . . . . . . . 0  . . . . . . . . . . 8  . . . . . . . . . 4(5)  . . . . . . . . 4 . . . . . . . . . 2
+Conscript  . . . . . . . . . . . . . . . . 10 . . . . . . . . . 10  . . . . . . . . . 10  . . . . . . . . . 10(12) . . . . . . . 5 . . . . . . . . . NA
+Rangers  . . . . . . . . . . . . . . . . . 15 . . . . . . . . . 15  . . . . . . . . . 10  . . . . . . . . . 20(25)  . . . . . . 7 . . . . . . . . . 4
+Infantry  . . . . . . . . . . . . . . . . . 22 . . . . . . . . . 22  . . . . . . . . . 10  . . . . . . . . . 20(25)  . . . . . . 5 . . . . . . . . . 4
+Machine-gunners  . . . . . . . . . 25 . . . . . . . . . 25  . . . . . . . . . 10  . . . . . . . . . 20(25)  . . . . . . 4 . . . . . . . . . 4
+Mechanised  . . . . . . . . . . . . . . 22 . . . . . . . . . 28  . . . . . . . . . 10  . . . . . . . . . 10(12) . . . . . . . 11  . . . . . . . . 4
+Armour  . . . . . . . . . . . . . . . . . 45 . . . . . . . . . 60  . . . . . . . . . 12  . . . . . . . . . 20(25)  . . . . . . 9 . . . . . . . . . 10
+Mobile Artillery  . . . . . . . . . . 25 . . . . . . . . . 8 . . . . . . . . . . 15(16)  . . . . . . 20(25)  . . . . . . 8 . . . . . . . . . 6
+Railroad Guns  . . . . . . . . . . . 50 . . . . . . . . . 12  . . . . . . . . . 17(18)  . . . . . . 20(25)  . . . . . . 3 . . . . . . . . . 8
+Saboteur  . . . . . . . . . . . . . . . . 0  . . . . . . . . . 0  . . . . . . . . . . 10  . . . . . . . . .10(12)  . . . . . . . 5 . . . . . . . . . 3IMPERIALISM: Fighting Battles 87
+CONTENTS
+--- page 92 ---
+TECHNOLOGICAL AD VANCES
+As the Indus t rial Revolution pr o gresses, new discov e ries and inventions multiply
+rapidl y. These advancements become a vailable on a world-wide basis; they canno t
+be ke pt secret. Howev e r, th e re are economic costs for using a new t e ch n o l o g y ; fo r
+exa mple, the cost of equipping your e x p e r t fa rm e r s with the new mec h a n i c a l
+reaper or the cost of re-training your military to use rifled artillery. 
+U s u a l l y, it is impossible to inv e st in ev e ry new t e chnology as it becomes av a i l a b l e
+for the f i rst time. Not only must you pick and choose among v a ri o u s
+a d vancements, but you must also decide how much of your Great Pow e r’s cash
+can go to t e chnology in the f i rst place. You have many uses for money, and not
+enough of it, especially at the beginning of the game.
+O ften you can aff o rd to wait. T e ch n o l o g y , once available, does not vanish. If y o u
+c a n n o t affo rd the co t ton gin in 1818, inv e st in 1830. On the other hand, you may
+never need to improve cotton output in your country. 
+Receiving a N otice of N ew Technology .
+When a new t e chnology f i rst becomes available, you see a st o ry with a large bold
+headline in the newspaper titled “New Inv e n t i o n . ” The text of the article giv e s
+you an idea of what this invention does so you can decide whether to invest in it.
+Your Minis ters might pr ovide additional reminders on a technology if one of them
+feels a particular t e chnology is im p o rtant. For ex a mple, the Defence Minist e r
+might remind you to invest in the latest military developments.
+If you are not sure what new t e chnologies are available, you can always find out
+by going to the Technology Investment screen.
+Technology Investment Screen.
+From the Terrain Map screen, click on the Invest in Technology button in the
+top row of the t o o l b a r . This button has a microscope on it. The most
+recently a vailable technologies alw ays appear at the top of the list, but you
+m ay need to look at sev e ral pages to view all of the t e chnologies as t h e
+game progresses.
+From this screen, you can look at the t e chnologies you already own, inv e st in new
+technologies, and view a detailed history about each technology. 
+Investing and Cancelling.
+To inv e st, click on a button listing the price of the new t e ch n o l o g y . The butt o n
+changes to the wor dPurchasing , and your cash is reduced by the amount shown on
+the button. If you c h a n g e your mind about this inv e stment, click on the butt o n
+again. The cash is restored to your reserves.
+You cannot cancel a purchase of t e chnology once you click the End T u rnb u t ton on
+the Terrain Map screen.IMPERIALISM: Technological Advances 88
+CONTENTS
+--- page 93 ---
+Viewing His tory.
+To view hist o rical inf o rmation about each t e ch n o l o g y , click on the picture of t h e
+te chnology on the I nve st m e n t s c reen. You can do this both bef o re and after y o u
+h ave inv e sted in a particular t e ch n o l o g y . Near the end of each hist o rical summary
+you can read a list of the benefits conf e rred by the t e chnology in the game. A
+s u m m a r y of these benefits appears on the Investment s c reen in the benefits column.
+E ve r y player always st a rts with the f i rst two t e chnologies listed below: H i g h
+Pressure Steam Engine and Seed Drill technology.
+Benefits of Technology Table.
+Approximate 
+Technology. Benefits of Technology. Arrival Date. Prerequisites.
+High Pressure Allows Engineers to build railroads through 1814 None
+Steam Engine farms, plains, deserts, forests, and tundra.
+Seed Drill Allows Farmers to improve Grain farms and 1814 None
+Orchards to Level I.
+Cotton Gin Allows Farmers to improve Cotton plantations 1816-20 None
+to Level I.
+Streamlined Hulls Allows construction of Clipper Ships. 1821-25 None
+Square-Set Timbering Allows Miners to improve Coal, Iron, Gold, 1821-25 High Pressure 
+and Gems mines to Level II. Steam
+Iron Railroad Bridge Allows Engineers to build railroads through  1821-25 High Pressure 
+swamps. Allows recruitment of a Forester unit Steam
+and improvement of Timber to Level I.
+Feed Grasses Allows production of a Rancher and to 1821-25 None
+improvement of Wool farms and Livestock 
+ranches to Level I.
+Spinning Jenny Allows Farmers to improve cotton plantations 1826-30 Feed Grasses 
+to Level II. Ranchers may improve Wool and Cotton Gin
+farms to Level II.
+Paddlewheels Allows building of a fast raiding and escort 1826-30 None
+vessel and a large merchant steamship.
+Steel and Iron Plows Allows Farmers to improve Grain farms and 1831-35 Seed Drill
+Orchards to Level II.
+Bessemer Converter Allows recruitment of Sharpshooters and 1836-40 None
+Scouts and upgrading of Light infantry and 
+Hussars to these more modern units.
+Compound Steam Engine Allows Engineers to build Railroad through 1836-40 Iron RR Bridge
+hills and Foresters to improve Timber 
+production to Level II.
+Rifled Artillery Allows recruitment of Field Artillery and 1841-45 None
+Siege Artillery regiments, and upgrading 
+of older artillery to these more modern units.
+Breech-Loading Rifles Allows recruitment of Rifle Infantry, Guards, 1841-45 Bessemer 
+and Carbine Cavalry and upgrading of older Converter
+regiments to these modern units.
+Advanced Iron Working Allows construction of Ironclads. 1846-50 None
+Power Loom Allows Farmers to improve cotton plantations 1846-50 Spinning Jenny
+to Level III and Ranchers to improve Wool 
+farms to Level III.IMPERIALISM: Technological Advances 89
+CONTENTS
+--- page 94 ---
+Mechanical Reaper Allows Farmers to improve Grain farms to 1851-55 Iron and Steel
+Level III.
+Commercial Fertiliser Allows Farmers to improve Orchards to 1856-60 Iron and Steel 
+Level III.
+Oil Drilling Allows building of a Driller and production 1856-60 None
+of Oil at Level I. Prospect for Oil in Desert, 
+Tundra, and Swamp. Build Refinery and   
+Power Plant on the Industry screen.
+Barbed Wire Allows Ranchers to improve Livestock ranches 1861-65 Feed Grasses
+to Level II.
+Steel Armour Plate Allows construction of Advanced Ironclads. 1866-70 Advance Iron 
+working
+Large Artillery Allows recruitment of Railroad Gun and 1871-75 Rifled Artillery
+Mobile Artillery regiments and upgrading 
+older artillery to these more modern units.
+Dynamite Allows Engineers to build rail through 1871-75 Compound 
+mountains and Foresters to improve Timber Stream Engine 
+to Level III. Miners may improve all mines and Square Set 
+to Level III. Timbering
+Marine Engineering Allows construction of a fast, powerful armoured 1871-75 Steel Armour
+cruiser and an enormous, all steel freighter.
+Machine Guns Allows recruitment of Modern Infantry, 1876-80 Breech loading 
+Machine Gunners, and Rangers and Rifles
+upgrading older regiments to these more 
+modern units.
+Chemistry Allows Drillers to improve Oil wells to Level II 1876-80 Oil Wells and 
+and Ranchers to improve Livestock ranches Barbed Wire
+to Level III.
+Improved Range-Finding Allows construction of Dreadnoughts and 1881-85 Marine 
+Battle Cruisers. Engineering
+Internal Combustion Allows recruitment of armoured and 1881-85 Chemistry
+mechanised regiments and upgrading 
+older units to these modern types. Drillers 
+may improve Oil wells to Level III.
+Confirmation of an Investment.
+When you click the End T u rnb u t ton, any inv e stment made in t e chnology that turn
+a re final. Bef o re the next turn begins you r e c e i v e a full screen picture of the new
+te chnology on your desk conf i rming that your Great Power now has access to t h e
+n ew te ch n o l o g y . You may t a ke adv a n ta g e of the new discov e ry or invention on
+your new turn.IMPERIALISM: Technological Advances 90
+CONTENTS
+--- page 95 ---
+HIS TORICAL SCENARIOS
+The Recovery of F rance 1820.
+After the wars of Napoleon, and his final defeat in 1 815, France finds itself g reatly
+reduced in e x tent and viewed with suspicion by the other Great Pow e rs. Ac ro s s
+the channel, Br i tain is already an indus t rial pow e r, the f i rst in the w o rld. In t h e
+East, three conser vative empires, of ten acting tog ether, guarantee that F rance can
+n ever dominate Europe again. A serious lack of coal precludes, to an e x tent, t h e
+rapid industrialisation so successful in Britain.
+But France has adv a n ta g es. Her indus t ries are more advanced than any on t h e
+continent, and her size and population are gr e a ter than any power ex c e pt dist a n t
+Russia. The lack of unity in Ger m a n y and It a ly means that her bor d e rs are
+relatively secure.
+Suggested Player Great Power: France
+Victory Conditions : T wo-thirds of the votes in the Council of Governors
+Difficulty: HardIMPERIALISM: Historical Scenarios 91
+CONTENTS
+Iron Bridge. The increasing use of iron for construction r evolutionised bridge-building, transpor tation,
+and ar chitecture.
+--- page 96 ---
+Unification Movements 1 848-1890.
+P russia seeks domination in Ger m a n y, but the other German st a tes look to
+Au st ria, whose r e s o u r ces and population are much gr e a ter than those of Pr u s s i a .
+To the w e st, France seeks to ensure that no one power dominates a divided
+G e rm a n y. Can Prussia fight w a rs aga i n st these appar e n t ly st ro n g er pow e rs? Can
+P russia convince the other st a tes of Ger m a n y that their int e re sts lie in the north
+and east?
+I ta ly wants to unite. This may be possible if France or A u st ria is fr i e n d l y; but can
+Italy ever rise to true Great Power status?
+Suggested Player Great Powers: Prussia or Italy
+Victory Conditions: Two-thirds of the votes in the Council of Governors
+Difficulty: Hard for Prussia, Nigh-On Impossible for Italy
+Naval Competition 1882-End of the Game.
+The Kaiser wants a f l e et and a place in the sun. Br i tain wants to maintain t h e
+n aval supremacy she has enjoyed since 1805. Ger m a n y can gain the ability to
+p roduce more than Great Br i tain but the British do not need a big army. These
+factors may lead to war. 
+Suggested Player Great Powers: Germany or Great Britain
+Victory Conditions: T wo-thirds majority victory in any Council of Go vernors.
+If a third power wins in the council, the game ends and both Powers lose.
+Difficulty: Normal for both Powers.
+Note: This scenario is only available after you r e g i ster your copy of I M P E R I A L I S M .
+See the data card that came with your copy of I MPERIALISM for details.IMPERIALISM: Historical Scenarios 92
+CONTENTS
+--- page 97 ---
+TUTORIAL WALK THROUGH
+T o play a tut o rial, click on the scenario B o o k on the Im p e rialism screen. On t h e
+scenario selection screen, select the Tutorial option. Then choose one of se ven topics
+on the tut o rial pop-up dialog. Each of these plays for only a few turns — enough
+to give you a basic understanding of the particular topic cov e red. St e p - b y- ste p
+instructions are provided for each topic below.
+Tutorial Using Civilian Units.
+Civilian units are built on the I n d u st r ys c reen. T o learn how to build them f o l l ow
+the steps in the Industry tutorial. This tutorial tells you how to use civilian units on
+the Terrain Map screen, once they have already been built.
+All your civilian units follow similar rules but per form dif ferent jobs on the Terrain
+M a p s c reen. As you play each turn your available civilian units appear s e l e c te d i n
+order, one after another. This is called the unit cycle.
+First Turn.
+Prospector .
+The selected unit is now the Pr o s p e c to r . On the map this unit is surrounded by a
+flashing white outline. The same civilian appears in the toolbar.
+• Move the cursor around the map within your country. You can see the cursor 
+change over different terrain tiles.IMPERIALISM: Tutorial Walk Through 93
+CONTENTS
+Cotton Gin. Eli Whitney in vented a simple device that r evolutionised cotton g rowing. His cotton gin
+spun the cotton through a roller co vered with tee th and the seeds fell a way.
+--- page 98 ---
+O ver most types of land, including mountains and hills that are alr e a d y
+prospected, you see the cursor appear as a g reen ar row. The g reen ar row means if
+you click on that spot you will order the unit to move t h e re, but that t h e re is no
+work the unit can do. This is called deploying .
+• With the Prospector selected click on a forest tile (the g reen ar row cursor should 
+be showing) The Pr o s p e c t or deploys to that tile and turns gray, indicating that 
+he has acted this turn, but is not performing any work.
+Engineer is selected now, but since you actually do have w o rk for your Pr o s p e c to r
+you should going to f i rst cancel the Pr o s p e c to r ’s ord e rs and reassign him, bef o re
+dealing with the Engineer.
+• Place the cursor over the icon of the Pr o s p e c t or until you see a blue q u e stion mark.
+• With this question mark showing, click the mouse.
+• Read the dialog box that appears, and click on the button Rescind Orders .
+This moves the Pr o s p e c t or back to his st a rting point and makes him the select e d
+unit again. 
+• W i th the Pr o s p e c t or selected again move the cursor over hills and mountains 
+until you find an eye cursor.
+• Click with the eye cursor showing. The Pr o s p e c t or will move to that location 
+and begin looking for minerals. 
+You see the unit animate when w o rking, “grayed-out” when inactive. This w o rk
+will take the entire turn. Next turn the prospector appears in the unit cycle again.
+Engineer .
+Now you cycle to the Engineer. Like the Prospector, he has a flashing white outline
+and appears in the toolbar indicating he is selected.
+The Engineer is capable of building f o rts, ra i l road tr a c k, ports, and depots. This
+t u rn, you should build a depot at the end of the r a i l road from the capital city.
+Depots and ports are used to gather resources from the tiles around them. Without
+a place to collect the r e s o u r ces and make them available for tr a n s p o r t to indus t ry,
+the production of a terrain tile cannot be used. 
+• W i th the engineer selected, place your cursor on the tile he occupies. Y ou see a 
+hammer cursor.
+• Click the mouse on that tile with the hammer cursor showing. A dialog appears.
+• On the cons t ruction dialog, click on the depot button. The Engineer begins 
+constructing a depot. 
+The unit becomes animated when working. This unit constructs forts and ports in
+the same way, using the same cons t ruction dialog. For building rail, a cursor of
+railroad track indicates the spaces he can build in.IMPERIALISM: Tutorial Walk Through 94
+--- page 99 ---
+Miner .
+The next unit in the cycle is the Miner. Miners open new mines, and impr ove older
+mines in hills and mountains. They cannot open mines unless the Pr o s p e c t or has
+a l ready found minerals t h e re. This turn your miner will im p rove an e x i sting mine
+in the space where he now is.
+• W i th the Miner selected, place your cursor on the tile he occupies. You see a 
+hammer cursor.
+• Click on that space with the hammer cursor showing. The Miner begins to  
+a n i m a t e. When he is done w o rking the mine will be bigg e r, and will produce 
+more iron ore.
+Forester.
+Next the F o re ster appears in the cycle. This is the f i rst turn the F o re ster has been
+available so none of the f o re st production has been im p roved. Although this unit
+is capable of im p roving output in any har d wood f o re st, it would be wise to st a rt
+i mp r oving a f o re st near a city, port, or depot. Only then will your tr a n s p o r t
+network gain the increased timber output immediately.
+T h ree tiles north of the capital city you can see a lighthouse icon in the midst of a
+l a rge fo re st. This r e p resents a port built earlier in the game, which g a th e r s timber
+from its own tile and all six surrounding tiles of forest.
+• W i th the f o re ster selected, move your cursor across the f o re st tiles around the 
+port. Look for the hammer cursor again.
+• Click with the hammer cursor showing. The F o re ster moves to the indicated 
+terrain tile and begins working. This is verified by the animation of the Fores ter 
+chopping a tree.
+Rancher .
+Your last civilian is a Rancher. Ranchers impr ove the output of sheep ranches and
+cattle r a n ge te rrain. U n fo rt u n a te l y, you have no liv e stock or sheep tiles near y o u r
+p o rts, depots, or your capital. The R a n cher can w o rk on the space he is curr e n t ly
+standing in, but this won ’t help until a depot or port is built nearb y. Since you don ’t
+need e x t ra live stock right now, t h e re is no reason to inv e st in a new port or depot
+to pick up this liv e sto c k. Given these f a c to r s, and the absence of sheep f a rms in
+your country, it was a mistake construct a Rancher. 
+• W i th the R a n cher selected, click on the disband button on the t o o l b a r . This 
+button has an icon with a human figure and a line through it.
+• On the dialog that appears click OK. The R a n cher vanishes but the w o rker 
+used to construct this unit returns to the Industry screen where he came from.
+Un l i ke other or d e rs, you cannot rescind the decision to disband a unit, alt h o u g h
+you can always rebuild that unit again lat e r. You have now com p l eted the unit
+cycle of civilians for this turn.
+• Click on End Turn at the bottom of the toolbar.IMPERIALISM: Tutorial Walk Through 95
+--- page 100 ---
+Second Turn.
+This turn, you go t h rough the unit cycle again, but only one unit has finished w o rk.
+Prospector .
+If the spot you or d e red pr o s p e c t ed last turn had nothing of value you will now see
+a pick a xe and a red “X” in the tile near your selected Pr o s p e c to r . If the tile did
+include minerals, you see an icon of some minerals in the upper - l e ft corner of t h e
+terrain tile.
+• Ra ther than using the eye cursor to hunt for the next tile to prospect, click on 
+the tiny mountain tile shown on the toolbar under the picture of the Prospector .
+• The screen centres on an mountain tile. Click on this tile with the eye 
+c u rs o r . This f e a t u r e helps find tiles to prospect when most of the country has 
+been searched.
+• The rest of your units are still working. Click on End Turn .
+Third Turn.
+• Continue using the Pr o s p e c t or to look for minerals. You can find un p ro s p e c t ed 
+spaces by using the eye cursor or the t o o l b a r . Your other units are still 
+performing work assigned on the first turn.
+• Click on End Turn .
+Fourth Turn.
+• Continue using the Prospector to look for minerals.
+Engineer .
+The Engineer has finished the work of building a depot. In his tile, you see a small
+building with two green lights near it. The green lights mean that the depot is
+c o n n e c t ed to the tr a n s p o r t net wo r k. If t h e re was a break in your r a i l road tr a c k,
+the lights would turn red.
+There is nothing to be done by the Engineer in his present location. 
+• Using the Green arrow cur s o r, click on the map within one tile of something 
+you would like to connect. While deploying the Engineer will accomplish no 
+work. Next turn he can work in his new location.
+(Suggestion: deploy to the southern part of the country somewhere along the mos t
+s o u th e r n ra i l road line you have. From t h e re the Engineer can e x tend the r a i l ro a d
+t rack further south tow a rd a distant, and curr e n t ly unconnected, iron ore mine.
+The best tile is one tile northwest of the town at the end of the line.)
+Your Miner and F o re ster are finished developing their spaces. You see additional
+st ru c t u r es built where t h ey we re wo rking, v e rifying that the output in those tiles
+has increased.IMPERIALISM: Tutorial Walk Through 96
+--- page 101 ---
+• Click on spaces with the hammer cursor showing to assign the Miner and the 
+Fo re ster to keep w o rking. If you need to find a new tile to w o rk in, click on the 
+tiny tiles in the toolbar to centre the map.
+• Click on End Turn
+Fifth Turn.
+• Continue using the Prospector to look for minerals.
+• Continue to use the Engineer to connect additional r e s o u r ces to your tr a n s p o r t 
+n et wo r k. This turn build r a i l road in a sout h we s t direction tow a rd the co t ton 
+p l a n t ation and the unconnected iron mine by clicking with the rail cursor 
+adjacent to his present location.
+You have completed this civilian unit tutorial. 
+Tutorial Using Military Units.
+You can build milit a ry units on the Indus t ry screen. This tut o rial cov e rs mo v i n g
+and fighting with land military units.
+Your Great P ower of Zimm has decided to strike the Minor Nation of Pram across
+your east e rn bor d e r. Although the diplomats came up with a pretext for the w a r,
+the best reason for taking o ver Pram is to pr event ano ther P ower from using it as a
+staging area for invasion. After all, Pram shares a border with your capital city.
+Scouting.
+• To scout your enemies prior to your invasion, move your cursor over the small 
+tent near the town labelled “Demerest” in Pram
+• With a red question mark cursor showing, click near the tent.
+You r e c e i v e the best es t i m a t e your off i c e rs can provide on the f o rces in t h a t
+province.
+Selecting.
+Your attack f o rce is located in the province of Sussex. To activ a te and order t h e s e
+forces, they must be selected .
+• Move the cursor over the small tents near the town in Sussex. Look for a f l a g
+and arrow.
+• W i th the flag and arrow showing, click on the tents. The g a rrison of t h e
+p rovince of Sussex appears in the t o o l b a r , and the tents in Sussex now have a
+flashing white outline. This garrison is now selected.IMPERIALISM: Tutorial Walk Through 97
+CONTENTS
+--- page 102 ---
+Marshaling Your Forces.
+The entire g a rrison is selected, but you may want to leave some of them behind
+when you attack. You can use the toolbar to make these decisions.
+• Click on the down pointing arrow near the Light Inf a n t ry regiment shown in
+the toolbar. Hot text in the upper-right helps you identify the Light Infantry.
+The number “1” between the two ar rows changes to a zero, while the number “1”
+under the unit picture remains. Now these numbers are telling you that you s t i l l
+have one Light Infantry in the gar rison but that this regiment is no longer selected
+to give orders to.
+The four regiments in the upper-right corner of the toolbar display ha ve no ar rows
+w i th them because t h ey are local militia who cannot be or d e red to leave t h e i r
+home province. 
+Since these militia remain behind in any event, you should pr o b a b l y attack with
+all the rest of your forces.
+• Click on the up arrow near the Light Inf a n t ry to r e sto re this regiment to t h e
+selected force.
+Ordering an Attack .
+• W i th the regiments selected, move your cursor over the enemy province of
+Demerest. Look for a crossed swords cursor.
+This is easier to find if you do not mo ve your mouse directly o ver the t own because
+near the town, the scouting cursor appears again.
+• Click an y w h e r e in the province with the crossed sw o rds showing to order t h e
+attack.
+You see a red ar row appear in Demerest. If you had ordered your units to mo ve to
+a friendly province, this arrow would be green.
+• Click on the red arrow with the blue q u e stion mark cursor showing. A dialog
+appears, confirming the forces and their order.
+• Click OKto confirm the orders and dismiss the box.
+• Click on End Turn at the bottom of the toolbar to advance to the battlefield.
+Fighting a Battle: Initiative, Moving, Firing.
+Your Defence Minis ter appears and asks you if you want him to deploy the troops. 
+• Since this should be a simple victor y, click OK. Otto-Deploy is fas ter than doing it
+yourself.
+Tactical combat is fought based on initiative. Each regiment acts in an order based
+on experience, leaders, and the type of unit. Generally ca valry acts before infantr y
+which acts before artillery.
+• To move the regiment with initiative click on a dot shown on the battlef i e l d .
+Green dots are safe from enemy fire. Red dots are in range of enemy forces.IMPERIALISM: Tutorial Walk Through 98
+--- page 103 ---
+• To find an enemy in range, mo ve your cursor o ver po tential tar gets. If the tar get
+is in range of the unit with initiative, you see a Cross Hairs cursor. If your unit is
+out of range, you see a Cross Hairs with a red “X” through it.
+• To fire, click on an enemy in range.
+M o st units can move and f i re in the same turn. If t h ey do not f i re at an enemy, t h ey
+a u to m a t i c a l l y re s e rve their f i re for the f i rst enemy regiment that moves in r a n ge. 
+• To end the turn of a unit without moving as far as possible or without f i ring, click
+on the done button in the tactical t o o l b a r . This is the middle of the t h ree butt o n s .
+• When all the enemy f o rces have surr e n d e r ed or fled, you are no t i fied of y o u r
+victory. Click OK to advance the turn.
+Fighting a Battle: Losses and Morale.
+As regiments are damaged, their status bars c h a n g e from green to show red and
+ye l l ow sections. Red r e p resents actual wounded or killed soldiers. Y e l l ow
+re p resents soldiers whose morale has br o ken and who wish to flee from t h e
+battlefield.
+When a unit’s bar is all red and/or y e l l ow the regiment heads off the battlefield as
+rapidly as possible. If enemies are too near, the regiment may choose to sur render .
+If the bar disappears completely, the regiment has been destroyed.
+Battle Reports.
+Fighting on the tactical battlefield is an option that may be turned on or off in the
+p re fe r ences screen. R e ga r dless of which mode of combat resolution you pr e fe r,
+you receive a summary of all the tur n’s battles called a battle report. This turn the
+only report is the battle you just fought.
+• Click on the lar ge wooden  “i”button to bring up the de tails on all the units who
+just fought.
+When you fight more than one battle, the arrows allow you to cycle t h rough all
+the battle reports for that turn.
+New Turn.
+You should now allow your f o rces in Demer e st to heal bef o re continuing t h e
+attack. Regiments which are not moving heal during their turn.
+When t h ey are r e a d y , you can continue to practice your skills ag a i n st Pram, or
+sta rt a new game of your own. For a pr o p e r ly balanced game, you should begin
+again since many military forces have been added to this tutorial.
+Tutorial for Using N aval Units.
+For this tut o rial your Great Power possesses one Fr i ga te and two Ships-of-t h e - L i n e .
+The Fr i ga te is stationed off the coast of Deneb, while the two other ships are
+stationed in home w a te rs. Your country is at war with Deneb.IMPERIALISM: Tutorial Walk Through 99
+CONTENTS
+--- page 104 ---
+Selecting.
+• Place your cursor over the f l e et just off your coast, until you see a pennant with
+an arrow. 
+• Click to select this fleet with the pennant and arrow cursor.
+Patrolling.
+A patrolling fleet attem pts to intercept hostile ships entering or s tationed in the sea
+zone of the patrol. The three buttons directly abo ve the fleet in the toolbar control
+how aggressive the captains of the patrolling ships will be.
+• W i th the f l e et selected, click on the central button, showing two cannon icons,
+for normal aggressiveness.
+• W i th the f l e et selected, order it to patrol this sea zone by clicking an y w h e r e in
+the sea zone with the telescope cursor showing.
+The patrolling f l e et appears in the sea zone with a telescope symbol near it
+indicating a patrol. Other possible actions are defined by diff e rent cur s o rs and
+m a t c hing symbols Fleets can conduct landing missions in hostile t e rri to ry using
+the cannon cur s o r; move to a new sea zone with the wheel cursor or block a d e
+enemy ports shown by the red “X” ship cursor. 
+• Click on the fleet with the blue question mark cursor and read the dialog box.
+• Click on OK to confirm the fleet’s patrol orders.
+Orders for the F rigate.
+• Click on the Mini-map near the y e l l ow country of Deneb. Your Fr i ga te is
+stationed on the far side, near Deneb’s capital city
+• Click with the pennant and arrow showing to select this fleet.
+L i ke the Ships-of-the-Line, the fr i ga te could be or d e red to patrol, but a block a d e
+of Deneb’s capital would be more effective.
+• Place the cursor over the anchor icon representing the home port of Deneb. 
+• Click with the red “X” and ship showing to establish the blockade.
+• You have ordered both fleets. Click on End Turn .
+It might t a ke more than one turn for your blockading fr i ga te to succeed. When it
+does, you receive a report about the interception of enemy mer chants. You receiv e
+re p o r ts of naval battles in the same way. Since Deneb has no f l e et right now, y o u
+do not have to fight just yet.
+• On the battle r e p o r t screen click on the large wooden “ i ”b u t ton to read more
+information about a battle or interception.
+S o m e times, your blockade mer e ly fo rces the enemy to t a ke their cargo back to por t ,
+but if you are more f o rt u n a t e, you may cap t u re or sink their merchant ships as w e l l .
+You may continue to practice your naval tactics, but for a balanced game y o u
+should now start again.IMPERIALISM: Tutorial Walk Through 100
+--- page 105 ---
+Tutorial for Using the T ransport Screen.
+Your tr a n s p o r t net wo r k is used to move commodities in your country from to w n s
+and rural areas to the industrial centre of the capital city. 
+• Click on the Go to T r a n s p o r tb u t ton in the t o o l b a r . This button has an icon of a
+c ra te with an arrow under it. Hot text in the upper - right of the screen says G i v e
+Transport Orders when the cursor is over this button.
+In the Tra n s p o r ts c reen, all the possible commodities to tr a n s p o r t appear, but
+only the coloured icons are available in your country right now.
+• Place your cursor over v a rious icons and read the inf o rmation in the hot text in
+the upper-right part of the screen.
+The bar with the r a i l road car icon in the low e r- right part of the screen tells y o u
+h ow much of you tr a n s p o r t is being used over the total you have. Right now, two
+points of your total of twenty-four are not being used.
+• Click on the arrow to the right of the coal slider, one click, until the line under
+the slider turns green.
+A green demand line means that the amount to be tr a n s p o r ted satisfies t h e
+demand for that item. A red demand line means that indus t ry or w o rke rs re qu i r e
+more of that commodity.IMPERIALISM: Tutorial Walk Through 101
+CONTENTS
+Internal Combustion. Internal combustion replaced the s team engine in industry and then res tored
+mobility to the battlefield with the in vention of tanks.
+--- page 106 ---
+Although all demands are satisfied no w, you still ha ve one more point of transpor t
+capacity. 
+• Click on the ar row to the right of the timber slider to order the transport of nine
+units of timber. Timber is the most critical r e s o u r ce at the beginning of t h e
+game (with the exception of food).
+It might be the case that e x t ra food is being brought to the w o rke rs under t h e s e
+o rd e r s. If so, your tr a n s p o r ted food could be reduced to allow more timber, coal,
+or iron to make its way to industry.
+• Click on an arrow to the left side of one of the food sliders. The demand line
+turns red. This lets you know that your food orders are already set as low as you
+can af ford. If a smaller amount of food was transpor ted, the wor kers might ha ve
+to eat your reserves of canned food. Eventually workers could starve.
+You could check the amounts being tr a n s p o r ted without clicking by reading t h e
+hot text to the upper-right when a cursor is over a commodity.
+• Click on the arrow in the upper - l e ft part of the screen to re t u rn to the Te rra i n
+M a p s c reen. You now know how to use the tr a n s p o r t system. To increase t h e
+transport capacity available, build more in the railyard on the Industry screen.
+You can continue with this game or start one of your own.
+Tutorial For Using the Industry Screen.
+• Click on the Go to Industry button marked with a smoking factory icon.
+• Mo ve the cursor o ver the screen and watch the hot t ext in the upper-right corner
+for the names of the various buildings.
+• Open the w a rehouse by clicking on it. The w a rehouse is near the t o p - c e n t r e of
+the screen.
+The w a rehouse provides a list of the commodities available for your use, divided
+i n to production economies. For more inf o rmation see the “Production Economies”
+section, st a rting on page 52. 
+Giving Orders to Industr y.
+• Open the Clothing f a c to r y by clicking on it. This brings up the production 
+dialog for the factory.
+The left border of the screen pr ovides a summary of the labour (wor kers) presentl y
+in the city, in the same way that the w a rehouse shows available commodities. As
+you give or d e rs to indus t ry, these numbers go down as labour is assigned to w o rk
+and commodities are used up by the factory.
+The clothing f a c to r y has a capacity of one. That means you can make one unit of
+c l othing per turn. The six f a c to r ies and mills in the lower part of the screen all
+h ave limited capacity. All of them r e qu i r e labour and commodities from y o u r
+stockpile to produce anything.IMPERIALISM: Tutorial Walk Through 102
+CONTENTS
+--- page 107 ---
+• Click on the arrow to the right of the slider on the clothing factory dialog. 
+As you do this, the amount of available labour shown in the right border under
+the arm icon goes down by two, and the amount of fabric shown at the centre-top
+of the warehouse also goes down by two.
+The equation on the clo thing factory dialog tells you why this happens. Every time
+you order a new unit of clothing you expend two units of f a b ric and use (for t h i s
+turn) two units of labour.
+Note that the numbers under each w o rker type in the left border did not c h a n g e
+when you made the clothing. These w o rke rs are your permanent w o rk fo rce and
+their numbers decrease only when w o rke rs leave indus t ry per m a n e n t l y. The
+number under the arm icon shows how much of the labour of these w o rke rs
+remains available this turn.
+• Click on some other indus t ries in the lower section of the screen and give t h e m
+production orders as well. 
+Some of these indus t ries cannot make an y thing because your w a rehouse lacks t h e
+commodities they require. This is shown by a red “X” near the item you are shor t
+of. You may choose to lea ve these dialogs open, or close them af ter you ha ve given
+your orders. 
+• To close, click on the box in the upper-left of each dialog on a Mac, upper-right 
+in Windows ‘95. 
+The Food Processing Centre at the upper - l e ft of the screen and the R a i lya rd near
+the upper-right function just like one of these factories or mills, e xcept that there is
+no limit of capacity. This means you can produce as much canned food (out of r aw
+foods) or tr a n s p o r t capacity (out of lumber and steel) as you wish, as long as y o u
+have labour and the required commodities available.
+Increasing Capacity .
+One clothing per turn is not v e ry much. You could make more money by
+producing two per turn.
+• Click on the Clothing F a c to r y to open the production dialog unless it’s alr e a d y
+open on the screen.
+• Click on the brass button with the two factories in the upper-right of the dialog.
+This brings up the Clothing Factory Expander.
+The Expander tells you the cost of the expansion and what the capacity the factor y
+is when the expansion is completed.
+• Click the OK button on the Expander to order the increased capacity. S teel and
+Lumber are deducted from the w a rehouse at this moment. Expansion r e qu i re s
+no labour.
+Note scaf folding around your clo thing factory and a hammer and nail icon on the
+p roduction dialog. Both of these indicate the expansion is occurring this turn. It
+will be completed next turn.IMPERIALISM: Tutorial Walk Through 103
+--- page 108 ---
+Building a Unit.
+You need ships, civilians, and regiments to expand your Em p i re. Three buildings
+on this screen, the Shipy a rd, the U n i ve rs i t y , and the Ar m o u r y, cons t ruct t h e s e
+different unit types. This turn, build a Miner.
+• Click on the University to open the university dialog
+• Click on the Button with a picture of a Miner to recruit the Miner. 
+• If you are not sure which unit is the Miner, click on each button until you see
+the inf o rmation titled “Miner” in the panel to the right side of the dialog.
+Clicking on the buttons does not order the unit to be built.
+• To build a Miner, click on the right ar row under the Miner button. The number
+“1” appears under the picture letting you know you ha ve ordered one Miner. In
+the border to the left of the screen, the expert wor ker used to build the Miner is
+a c t u a l l y deducted from your w o rk fo rce per m a n e n t l y, so the icon r e p re s e n t i n g
+that worker disappears. 
+Next turn, the Miner appears on the Terrain Map.
+The Ar m o u r y and the Shipy a rd both w o rk exa c t ly like the U n i ve rs i t y , alth o u g h
+building ships does not require workers, just materials.
+Training Labour .
+To replace the labour of w o rke rs per m a n e n t l y deducted from Indus t ry you can
+improve the training level of your work force. 
+• Click on the Trade School to open the Trade School dialog
+• Make sure you have at least one labour still available. If you do not, open a
+p roduction dialog and reduce production. You must have at least one labour
+free to train.
+• Click on the ar row to the right of the top slider. This takes one untrained wor ker
+and orders it to be educated up to le vel of trained wor ker this turn. The wor kers
+cannot work in a factory while being educated.
+E a ch level of training doubles the amount of labour perf o rmed. An untr a i n e d
+wo rker adds one point of labour to your total. A trained w o rker adds two points.
+The mighty expert worker adds four points of labour.IMPERIALISM: Tutorial Walk Through 104
+--- page 109 ---
+Mig ration.
+Even with training you need to increase population to keep your economy rolling.
+Using the Capitol Building you can recruit more untrained workers for Industry.
+• Click on the Capitol building to bring up the Migration dialog. 
+• Click on the arrow to the right of the slider to bring migrant w o rke rs to y o u r
+city by expending food, clothing and fur n i t u r e to im p rove their st a n d a r d 
+of living.
+The amount of new w o rke rs that can migr a te to indus t ry each turn is limited by
+the size of your country. Remember that each new w o rker must have food to eat
+every turn.
+You have now learned the basics of Industry in I MPERIALISM .
+• Click on the arrow in the upper-left to return to the T errain Map screen. 
+• Click on End T u rnon the Te rrain Map s c reen to advance to the next turn and
+check the results of your production and unit building orders. You can continue
+to play this game or start one of your own.
+Tutorial For Conducting T rade.IMPERIALISM: Tutorial Walk Through 105
+CONTENTS
+Merchant Marine
+Capacity
+Commodities
+in Demand
+Bid Bar sOffer Bar s
+--- page 110 ---
+Bid and Of fersscreen.
+• Click on the Go to Trade button marked with a dollar sign icon.
+The Bid and Off e rss c reen allows you to set bids to try to buy things you w a n t ,
+and to offer for sale items you hope other countries want to buy. Gener a l ly
+speaking it is best to bid on r e s o u r ces and sell finished goods. This allows you to
+make a profit.
+• Look at the left border of the screen. The icons appearing t h e re are r e s o u rc e s
+that your indus t ry needs. To bid on some of these r e s o u r ces, click on the br a s s
+bars in the orders column next to the commodity icons. 
+When a bar slides out, the word Bidappears on it. 
+• To offer a commodity for sale click on the brass bars on the other side of t h e
+orders column. 
+Note that when the bar slides out, it has the w o rd O ffe ron it. When the bar f i rst
+slides out, you are offering the most you can sell.
+• To reduce the amount you are off e ring for sale, click on the white arrow to t h e
+left of the Quantity to Offer slider. 
+• Click on the arrow in the upper - l e ft part of the screen to re t u rn to the Te rra i n
+Map screen. 
+• The next step is ending your turn using the End T u rnb u t ton in the low e r- right of
+the Terrain Map screen.
+Offer Sheets.
+When you end your turn you begin to receive of fer sheets for the items you bid on.
+If you do not r e c e i v e offer sheets you need to t a ke diplomatic actions to im p rove
+your relations. This improves your chances of obtaining offer sheets.
+• Click either Accept or Reject on the of fer sheet. Before you accept you might want
+to change the quantity being accepted.
+• To view a market for one commodity, click on the tabs on the right side of t h e
+screen. This opens the trade book.IMPERIALISM: Tutorial Walk Through 106
+--- page 111 ---
+The T rade Book .
+The Trade Book d i s p l a ys the nations bidding on the selected commodity on t h e
+right hand page, and displa ys the sellers on the left. Under the names of the selling
+c o u n t r ies are the flags of the bidders, in the order of pr e fe rred trading par t n e rs .
+You are allowed to view only those markets where your bidders are present.
+One of your goals is to get your country to the top position with a few of t h e s e
+o ffe ring nations. That way you can be sure of receiving the offer each turn it is
+made, before the other bidding nations get the chance to accept the deal. 
+• To re t u rn to the offer sheets click on the check mark seal in the corner of t h e
+Trade Book .
+Once you act on all your off e rs, or run out of merchant marine, the trade off e rs
+part of your turn ends.
+The Deal Book .
+A fter the trade off e rs of all countries have been dealt with, and bef o re the new
+t u rn begins, you see your Deal Book . It r e p o r ts all the trades and potential tr a d e s
+you made or could have made this turn.
+• Click on any curled page corner to turn the pages and see more.
+• Click on a tab on the right of the screen to visit the trade book. The information
+available in the Trade Book is the same as earlier during the trade off e rs part
+of your turn. You are able to access only those mar kets which you bid on during
+this turn. From the Trade Book you click on the check mark seal to re t u rn to
+the deal book.
+• Click on the arrow in the upper - l e ft from either the Trade Book or the D e a l
+Book to advance to the next turn of I MPERIALISMIMPERIALISM: Tutorial Walk Through 107
+Treasur y
+Reject This Of fer Accept This Of fer Remaining Mer chant MarineView Mar ket TabsHelp & Information
+Commodity Of fered
+Offering Nation
+Price
+Click here to mak e
+this the Final Of fer
+for this Type of 
+Commodity
+--- page 112 ---
+Tutorial For Using the Diplomacy Screen.
+First Turn.
+• From the Terrain Map screen, click on the Go to Diplomacy button. It has an icon
+of a diplomat’s top hat on it. Hot text in the upper - right also helps you identify
+this button.
+Obtaining Information.
+When you decide to make a nation a frequent trading partner and to impr ove your
+relations with that nation, it is called “cour t i n g . ” Your long-t e rm goal when
+c o u r ting is to gain control of the nation peacefully. It is unwise to court nations
+w h i c h you plan to conquer milit a ri ly any way, since the assets you spend cour t i n g
+that country are then wasted.
+Your Great Power does not have enough cash, trade goods, or merchant mar i n e
+to court all the Minor Nations in the world so your fir st step is to de termine whic h
+nations to court.
+• To obtain information about the products produced in the Minor Nations, click
+on the small green circle with a white ship in the low e r- c e n t r e of the scr e e n .
+Then click on any Minor Nation on the map. This selects that nation and causes
+it to be outlined in white. You see on the lo wer-right part of the screen the major
+exports of the selected nation.
+• Click on v a rious Minor Nations on the map, observing what commodities t h ey
+a re like ly to e x p o r t. Your Great Power is short on coal and iron, so pay special
+attention to nations who sell those resources.
+• Click on the o ther Great P owers and see which Minor Nations are already being
+cour ted by o ther Great P owers. If the o ther po wers es tablish trade consulates in
+a Minor Nation, it means that they intend to court those nations.
+• Click on the icon dir e c t ly above the green circle. This displays the level of
+f riendliness (relationships) of all the countries in the game. You use this to see
+which Minor Nations are friendly to those nations you plan to trade with. 
+A l though many Minor Nations sell one or both of coal and iron, the best ones to
+court are Issa and Zinlu. This is true because of the following factors:
+1. Your neighbour Loke is a poor nation which is not wor th trading with but whic h
+you will need to conquer later in the game if only for security reasons. Issa and
+Zinlu are not especially fr i e n d l y with Loke. You should court countries that are
+not friendly with lands you plan to in vade, since your in vasion hurts relations wit h
+everyone friendly with the nation(s) you invade.
+2. Zinlu and Issa are friendly to each other
+3. Neither nation has a land border with o ther Great P owers. This means they ar e
+unlikely to be invaded right away.
+4. Zinlu, at least, is not being courted by any other Great Power.IMPERIALISM: Tutorial Walk Through 108
+CONTENTS
+--- page 113 ---
+Taking Actions.
+Once you have decided which nations to court, you use, for the f i rst time, the large
+tabs on the low e r- right of the screen. This turn you should use the Offer Treaties ta b .
+• Click on the Offer Treaties tab.
+• Click on and select the scroll labelled Trade Consulate .
+• Click on Issa and Zinlu on the map. You see a y e l l ow scroll icon appear wit h i n
+the bor d e rs of those nations conf i rming you have paid for the cons t ruction of a
+trade consulate in those nations. This is the fir st step in courting Issa and Zinlu.
+• Click on the arrow in the upper - l e ft of the screen to re t u rn to the Te rrain Map
+s c reen. You have finished your diplomacy for this turn. You may end your turn
+n ow, or t a ke actions on other screens bef o re ending your turn. The End T u rn
+button is on the lower-right of the Terrain Map screen.
+Second Turn.
+Obtaining Information.
+• From the Terrain Map screen, click on the Go to Diplomacy button. 
+• W i th your own Great Power selected and outlined in white, click on the scr o l l
+icon in the low e r- c e n t r e of the screen. You see a small dollar sign icon in Issa
+and Zinlu confirming that you now have trade consulates there.IMPERIALISM: Tutorial Walk Through 109
+Dynamite. Although dynamite has many military applications, mining and construction also benefited
+from this explosive in vented in 1866.
+--- page 114 ---
+• Click on the small g reen circle icon in the lo wer-centre of the screen. Then click
+on v a rious Great Pow e rs. You are checking to see if any of your com p et i to r s
+have taken more “courting” actions in Issa or Zinlu.
+Notice that when P a tagon and Kem are selected, t h e re is a green circle labelled
+5% within the bor d e rs of Issa. This means that your com p et i to r s have off e red Issa
+a 5% trade subsidy in hopes of im p roving their chances at Issa’s r e s o u r ces and
+markets. No competitors have offered Zinlu a subsidy.
+Take actions.
+• Click on the large green circle tab in the low e r- right of the screen. This t a ke s
+you to the trade policies screen. Here you offer subsidies to com p ete fo r
+resources and markets with your foes.
+• Click on the g reen button labelled 5% then click on Zinlu on the map. You see a
+green icon appear inf o rming you that you off e red Zinlu a 5% trade subsidy.
+Since no other Great Pow e rs are courting Zinlu right now this should put y o u
+ahead in the race for Zinlu’s resources and markets.
+• Click on the green button labelled 10%, then click on Issa. By off e ring Issa a
+l a rger subsidy than those off e red by Kem and P a tagon, you hope to move into
+first place as Issa’s favourite trading partner.
+• Click on the arrow in the upper - l e ft of the screen to re t u rn to the Te rrain Map
+screen. 
+You are finished with the Diplomacy Tutorial. The next s tep is to open Embassies
+in the nations you plan to court. This costs $5000. You should also seek to tr a d e
+frequently with Issa and Zinlu to improve relations as rapidly as possible. 
+You may continue this game, or start one of your own.IMPERIALISM: Tutorial Walk Through 110
+--- page 115 ---
+HOT KEY LIS T
+Hot keys available from transport, trade, industry or diplomacy or map:
+1 . . . . . . . . . . . . . . . . . . . . . . . . . . . . go to transport screen
+2 . . . . . . . . . . . . . . . . . . . . . . . . . . . . go to industry screen
+3 . . . . . . . . . . . . . . . . . . . . . . . . . . . . go to trade screen
+4 . . . . . . . . . . . . . . . . . . . . . . . . . . . . go to diplomacy screen
+5 . . . . . . . . . . . . . . . . . . . . . . . . . . . . go to technology screen
+Hot keys available from any screen:
+F1 for Windows 95  . . . . . . . . . . . . . Help and Information (like clicking the query button)
+“h” for Macintosh  . . . . . . . . . . . . . Help and Information (like clicking the query button)
+Hot keys available from Tactical screen:
+Space Bar  . . . . . . . . . . . . . . . . . . . . Next Target
+“d” . . . . . . . . . . . . . . . . . . . . . . . . . . Done With Move
+Hot Keys available from Diplomacy/Bids and Offers screen:
+Escape  . . . . . . . . . . . . . . . . . . reject the offer
+Return  . . . . . . . . . . . . . . . . . . accept the offer
+Hot Keys available from the Terrain Map screen:
+“w” . . . . . . . . . . . . . . . . . . . . . . . . . . Rouse civilian units with “Sleep” orders and naval units
+with “Defend orders”IMPERIALISM: Hot Key Lis t 111
+CONTENTS
+Commercial Fertiliser .John La wes fir st treated phosphates with sulfuric acid, significantly impr oving
+the ef fectiveness of fertilisers.
+--- page 116 ---
+STRATEGY IDEAS
+A game of I M P E R I A L I S M tends to ev o lve in t h ree phases, which can be t e rm e d
+D evelopment, Diplomacy, and Des t ruction. The emphasis is diff e rent for each phase.
+Tips For the Development Phase.
+At the beginning of the game, your gr e a te s t lack is money. Early development of
+reliable income sources gets you off to a f a st sta rt. This is best done by f i n d i n g
+Minor Nations which produce r e s o u r ces you are short of, and trading with t h e m
+eve ry turn. Using trade consulates and subsidies you can guar a n tee these Minor
+Nations want to purchase your goods ahead of those of the other Great Pow e rs .
+Do not spread your eff o rts be t ween too many diff e rent Minor Nations. This oft e n
+causes you to fall behind in all of them, losing the battle for markets.
+Wi th consistent income from the sale of goods, you purchase new t e ch n o l o g i e s ,
+build new civilian units, and cons t ruct lots of rail depots and ports. While you are
+looking for gold, coal and iron, consider building a depot or port with plentiful
+timber immediat e ly. Timber dr i ves your early development even more than do
+coal and iron because timber is r e qu i r ed to produce both paper and lumber.
+G e n e ra l l y, the bigg e st re st rictions on early development result from deciding
+between: 1) training and new units (paper); 2) the need for transport and industrial
+capacity (lumber along with steel); and, 3) the need for w o rker migration to
+i n d u st r y (fur n i t u r e, along with canned food and clothing). Timber is the only
+resource required for all three.
+On the indus t ry screen, you must s t ri ve to maintain a balance be t ween labour,
+i n d u st r ial capacity, and raw r e s o u r ces available to indus t ry (th rough either tr a d e
+or tr a n s p o r t). When one of these items shows a surplus, w o rk on increasing t h e
+oth e rs to maintain rough eq u a l i t y . At the beginning of the game your short a ge is
+l i ke ly to be labour. Often an early increase to the size of the lumber mill f o ste rs
+rapid development.
+The most im p o rtant t e chnologies early in the game are the iron r a i l road br i d ge which
+a l l ows the doubling of timber output, and sq u a re - s e t timbering which allows t h e
+doubling of mineral outputs. These should be purchased as soon as t h ey are available. 
+If you want to fight a war during this period, a single frigate can do a g reat deal of
+damage as a privateer before the other Great Powers build their navies. IMPERIALISM: Strategy Ideas 112
+CONTENTScontinues...
+--- page 117 ---
+Tips For the Diplomacy Phase.
+G ra d u a l l y your int e rnal production and indus t rial outputs provide surpluses and
+p e rmit you to focus on other nations as well as your own. For Minor Nations t h i s
+means obtaining colonies, either by defending them from agg ression of o ther g reat
+Powers, or by diplomatic and development actions.
+The f i rst step is inv e sting in Embassies with those few Minor Nations you have a
+good chance to win to your side. Always f o l l ow an embassy with a non-aggr e s s i o n
+pact. Next, send in your Pr o s p e c to r , your Dev e l o p e r , and other civilian units. By
+i n c reasing the output of the Minor nation, you increase the trades you can make
+w i th them each turn. This speeds the im p rovement in your relationships. While
+this is happening, you need to g reatly augment your mer chant marine to deal wit h
+the increasing volume of trade.
+G rants (or bribes) serve to help you maintain a lead over other Great Pow e rs, but
+it is g e n e ra l l y be t ter to use the money for development f i rst, and only make
+significant g rants if you ha ve a subs tantial surplus. Although g rants to o ther Great
+Powe rs do reduce the risk of w a rs, it is g e n e ra l l y a be t ter idea to provide grants to
+Minor Nations first.
+D u ring this period of the game you must be cautious in st a rting w a rs due to t h e
+h a rm your relationships suffer when you declare w a r. Fighting def e n s i ve l y can be
+a great benefit howev e r. One good s t ra tegy for early w a rs is to stockpile a large
+number of arms and then when you can upgrade your f o rces to do so all at once
+using your large stockpile. St a rting a war bef o re your enemies have upgr a d e d
+provides a significant edge.
+Tips For the Destruction Phase.
+When all or nearly all of the Minor Nations have been conq u e red or colonised
+you should change your aims to destruction of your foes. This does not necessaril y
+mean st a rting a w a r; but it means that you must be pr e p a r ed for more dir e c t
+c o n f ro n t ations. Building a large stockpile or arms, inv e sting in a modern na v y,
+and upgrading your land forces whenever possible are keys.
+Notice which r e s o u r ces you are short on, and protect your sources of those it e m s .
+Try to expand ag a i n st a w e a ker power f i rst, and make sure that no one Gr e a t
+Power commands a large lead in the Council of Governors.
+If you follow these rules successfully, your chances for eventual victory are good.IMPERIALISM: Strategy Ideas 113
+CONTENTS
+--- page 118 ---
+FROG CITY CREDIT S
+Executive Producer. Rachel Bernstein
+Original Game Design. Bill Spieth, T ed Spieth
+Design T eam. Rachel Bernstein, Eric Fredricksen
+Alexander Peck, Bill Spieth, T ed Spieth
+Programming. Rachel Bernstein, Eric Fredricksen,
+Alexander Peck
+FCLL. Eric Fredricksen
+Art. Marc Tanenbaum, Vadim Vahrameev
+Additional Art. Ric Tringali, Stephanie Wong, Troy Daniels, 
+ellipsis productions
+Manual. Bill Spieth, Cris Spieth
+Editor. Cris Spieth
+Newspaper Stories. Clark Cox, Alexander Peck, Bill Spieth,
+Ted Spieth
+Distraction. Samuel Bernstein Spieth
+T esting. Justin D’Arms, Tim Bak, Clark Cox,
+Bruce Sherin
+Special Thanks. Kathleen Cassidy, the Geebers, 
+Kristin Lamoreux, Cris Spieth, SSI
+IMPERIALISM was written with Apple ’s MacApp© Application F ramework, and por ted to Microsoft Foundation
+Classes using the Frog City Lepidopt e ran Libr a ry. The FCLL is wr i t ten in C++ and provides a platf o rm -
+independent interface for developing simultaneous Windows and Mac games. 
+SSI CREDIT S
+Producer. Carl C. Norman
+Associate Producer. Brandon Chamberlain 
+Director of R & D. Jan Lindner
+Art Director. Steve Burke
+Audio Director. Ralph Thomas 
+Audio Technician. Stephen Lam
+Multimedia Production. Maurice Jackson & Miki Morris
+Music Composed & Performed by. Danny Pelfrey and Rick Rhodes
+Violin Accompaniment. Jeremy Constant
+Manual Editors. Mark Whisler, Anathea Lopez
+Additional News Stories. Jeff Groteboer 
+Data Manager. Caron White
+Test Manager. Sean Decker
+Test Supervisor. Jason Ray
+Lead T ester. Kelly Calabro 
+SSI Testers. Forrest Elam, Cyrus G. Harris, Luke LaJoie,
+John Pena, Damon Perdue, Dave Pope,
+Nile Sabbagh, Sally Werner, Jeff Powell
+Graphic Design and DTP . Louis Saekow Design:
+Dave Boudreau & Jerrick McCullough
+Special Thanks to: Bret Berry, Joel Billings, Dan Cermak, Lee Crawford, Chuck Kroegel, John Ross, 
+Aaron Scheiber IMPERIALISM: Credits 114
+CONTENTS
+
+--- page 119 ---
+BIBLIOGRAPHY
+Barraclough, Geoffrey, (Ed.) Concise Atlas of World History , Times Books, London, 1982, 1994
+Briggs, Asa (Ed.) The Nineteenth Century , Thames and Hudson London, 1970.
+Burton, Anthony, Rise & Fall of King Cotton , London, 1984
+Chaliand, Gerard & Rageau, Jean-Pierre, Strategic Atlas: A Comparative Geopolitics of the
+World’s Powers Trans. T ony Berrett, Harper and Row, New York, 1985
+Cross, Robin (Gen.Ed.), Warfare: A Chronological History Welfleet Press, Quarto Publishing,
+London, 1991
+Fowler, William M. Jr., Jack Tars and Commodores: The American Navy 1 783-1815 Houghton
+Mifflin Company, Boston, 1984 
+Gillispie, Charles C. (Ed.) A Diderot Pictorial Encyclopedia of Trades and Industry v.1 , Dover
+Publications, New York 1959, 1987
+Grafton, Carol Belanger (Ed.), 3800 Advertising Cuts , Dover Publications, New York, 1991
+Grafton, John, New Y ork in the Nineteenth Century (2nd Ed.) Dover Publications, New York,
+1977, 1980
+Harter, Jim (Ed.), Transportation: A Pictorial Archive from Nineteenth Century Sources , Dover
+Publications, New York, 1984
+Heck, J.G (ed.), Heck’s Pictorial Archive of Military Science, Geography, and History , Dover
+Publications, New York, 1994
+Keegan, John, A History of Warfare , Alfred A. Knopf, New York, 1993
+Kennedy, Paul, The Rise and Fall of the Great Powers , Random House, New York 1987
+Lavery, Brian, Nelson’s Navy: The Ships Men & Organisation , Conway Maritime Press,
+London,1989
+Leckie, Robert, The Wars of America , Harper and Row, New York, 1968, 1981
+Ludwig, Emil, Bismarck , (trans. Eden and Cedar Paul) Little, Brown and Co., Boston , 1927
+Martin, Montgomery, Antique Maps of the Nineteenth Century World , Portland House, New
+York 1851, 1989
+Massie, Robert K. , Dreadnought: Britain, Germany, and the Coming of the Great War ,
+Random House, New Y ork, 1991
+Pakenham, Thomas The Scramble for Africa 1876-1912 , Random House, New York 1991
+Singer, Charles et. al. (eds.) History of T echnology v. 4: The Industrial Revolution c.1 750-1850 ,
+Oxford University Press, New York and London 1958
+Slosson, Preston, Europe Since 1815 , Charles Scribner’s Sons, New York, 1954
+Somerset Fry, Plantagenet, History of the World , Dorling Kindersley, London, 1994
+Stokesbury, James L., Navy and Empire , William and Morrow Co. New York, 1983IMPERIALISM: Bibliog raphy 115
+CONTENTS
+--- page 120 ---
+

--- a/src/diplomacy/mod.rs
+++ b/src/diplomacy/mod.rs
@@ -1,0 +1,964 @@
+use std::collections::HashMap;
+
+use bevy::prelude::*;
+
+use crate::economy::{Name, NationId, Treasury};
+use crate::turn_system::{TurnPhase, TurnSystem};
+use crate::ui::logging::TerminalLogEvent;
+use crate::ui::menu::AppState;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+struct DiplomacyPair(NationId, NationId);
+
+impl DiplomacyPair {
+    fn new(a: NationId, b: NationId) -> Self {
+        if a.0 <= b.0 {
+            DiplomacyPair(a, b)
+        } else {
+            DiplomacyPair(b, a)
+        }
+    }
+
+    fn contains(&self, nation: NationId) -> bool {
+        self.0 == nation || self.1 == nation
+    }
+
+    fn other(&self, nation: NationId) -> Option<NationId> {
+        if self.0 == nation {
+            Some(self.1)
+        } else if self.1 == nation {
+            Some(self.0)
+        } else {
+            None
+        }
+    }
+}
+
+/// Relationship tiers used for UI labelling and thresholds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelationshipBand {
+    Hostile,
+    Unfriendly,
+    Neutral,
+    Cordial,
+    Warm,
+    Allied,
+}
+
+impl RelationshipBand {
+    pub fn label(&self) -> &'static str {
+        match self {
+            RelationshipBand::Hostile => "Hostile",
+            RelationshipBand::Unfriendly => "Unfriendly",
+            RelationshipBand::Neutral => "Neutral",
+            RelationshipBand::Cordial => "Cordial",
+            RelationshipBand::Warm => "Warm",
+            RelationshipBand::Allied => "Allied",
+        }
+    }
+}
+
+/// Persistent diplomatic state between two nations.
+#[derive(Clone, Debug)]
+pub struct DiplomaticRelation {
+    pub score: i32,
+    pub treaty: TreatyState,
+}
+
+impl Default for DiplomaticRelation {
+    fn default() -> Self {
+        Self {
+            score: 0,
+            treaty: TreatyState::peace(),
+        }
+    }
+}
+
+impl DiplomaticRelation {
+    pub fn band(&self) -> RelationshipBand {
+        match self.score {
+            ..=-50 => RelationshipBand::Hostile,
+            -49..=-11 => RelationshipBand::Unfriendly,
+            -10..=10 => RelationshipBand::Neutral,
+            11..=39 => RelationshipBand::Cordial,
+            40..=69 => RelationshipBand::Warm,
+            _ => RelationshipBand::Allied,
+        }
+    }
+}
+
+/// Treaty flags following Imperialism's diplomacy flow.
+#[derive(Clone, Debug)]
+pub struct TreatyState {
+    pub at_war: bool,
+    pub consulate: bool,
+    pub embassy: bool,
+    pub non_aggression_pact: bool,
+    pub alliance: bool,
+}
+
+impl TreatyState {
+    pub fn peace() -> Self {
+        Self {
+            at_war: false,
+            consulate: false,
+            embassy: false,
+            non_aggression_pact: false,
+            alliance: false,
+        }
+    }
+}
+
+/// All relationships between nations.
+#[derive(Resource, Default)]
+pub struct DiplomacyState {
+    relations: HashMap<DiplomacyPair, DiplomaticRelation>,
+}
+
+impl DiplomacyState {
+    pub fn relation(&self, a: NationId, b: NationId) -> Option<&DiplomaticRelation> {
+        self.relations.get(&DiplomacyPair::new(a, b))
+    }
+
+    pub fn relation_mut(&mut self, a: NationId, b: NationId) -> &mut DiplomaticRelation {
+        let pair = DiplomacyPair::new(a, b);
+        self.relations.entry(pair).or_default()
+    }
+
+    pub fn ensure_pairs(&mut self, nations: &[NationId]) {
+        for (index, &a) in nations.iter().enumerate() {
+            for &b in &nations[index + 1..] {
+                let pair = DiplomacyPair::new(a, b);
+                self.relations.entry(pair).or_default();
+            }
+        }
+    }
+
+    pub fn adjust_score(&mut self, a: NationId, b: NationId, delta: i32) -> i32 {
+        let relation = self.relation_mut(a, b);
+        relation.score = (relation.score + delta).clamp(-100, 100);
+        relation.score
+    }
+
+    pub fn set_treaty<F>(&mut self, a: NationId, b: NationId, update: F)
+    where
+        F: FnOnce(&mut TreatyState),
+    {
+        let relation = self.relation_mut(a, b);
+        update(&mut relation.treaty);
+    }
+
+    pub fn relations_for(&self, nation: NationId) -> Vec<(NationId, &DiplomaticRelation)> {
+        self.relations
+            .iter()
+            .filter_map(|(pair, relation)| {
+                pair.other(nation)
+                    .map(|other| (other, relation))
+                    .filter(|_| pair.contains(nation))
+            })
+            .collect()
+    }
+}
+
+/// Representation of a recurring aid payment.
+#[derive(Clone, Debug)]
+pub struct RecurringGrant {
+    pub from: NationId,
+    pub to: NationId,
+    pub amount: i32,
+}
+
+#[derive(Resource, Default)]
+pub struct ForeignAidLedger {
+    recurring: Vec<RecurringGrant>,
+}
+
+impl ForeignAidLedger {
+    pub fn upsert(&mut self, grant: RecurringGrant) {
+        self.recurring
+            .retain(|g| !(g.from == grant.from && g.to == grant.to));
+        self.recurring.push(grant);
+    }
+
+    pub fn cancel(&mut self, from: NationId, to: NationId) -> bool {
+        let len_before = self.recurring.len();
+        self.recurring.retain(|g| !(g.from == from && g.to == to));
+        len_before != self.recurring.len()
+    }
+
+    pub fn has_recurring(&self, from: NationId, to: NationId) -> bool {
+        self.recurring.iter().any(|g| g.from == from && g.to == to)
+    }
+
+    pub fn all(&self) -> &[RecurringGrant] {
+        &self.recurring
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct OfferId(u32);
+
+impl OfferId {
+    pub fn raw(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DiplomaticOffer {
+    pub id: OfferId,
+    pub from: NationId,
+    pub to: NationId,
+    pub kind: DiplomaticOfferKind,
+}
+
+impl DiplomaticOffer {
+    pub fn new(from: NationId, to: NationId, kind: DiplomaticOfferKind) -> Self {
+        Self {
+            id: OfferId(0),
+            from,
+            to,
+            kind,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum DiplomaticOfferKind {
+    OfferPeace,
+    Alliance,
+    NonAggressionPact,
+    ForeignAid { amount: i32, locked: bool },
+}
+
+#[derive(Resource, Default)]
+pub struct DiplomaticOffers {
+    next_id: u32,
+    pending: Vec<DiplomaticOffer>,
+}
+
+impl DiplomaticOffers {
+    pub fn push(&mut self, offer: DiplomaticOffer) {
+        let mut offer = offer;
+        self.next_id = self.next_id.saturating_add(1);
+        offer.id = OfferId(self.next_id);
+        self.pending.push(offer);
+    }
+
+    pub fn iter_for(&self, nation: NationId) -> impl Iterator<Item = &DiplomaticOffer> {
+        self.pending.iter().filter(move |offer| offer.to == nation)
+    }
+
+    pub fn has_pending_for(&self, nation: NationId) -> bool {
+        self.iter_for(nation).next().is_some()
+    }
+
+    pub fn take(&mut self, id: OfferId) -> Option<DiplomaticOffer> {
+        if let Some(index) = self.pending.iter().position(|offer| offer.id == id) {
+            Some(self.pending.remove(index))
+        } else {
+            None
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.pending.len()
+    }
+}
+
+/// Orders issued during the player turn.
+#[derive(Message, Debug, Clone)]
+pub struct DiplomaticOrder {
+    pub actor: NationId,
+    pub target: NationId,
+    pub kind: DiplomaticOrderKind,
+}
+
+#[derive(Debug, Clone)]
+pub enum DiplomaticOrderKind {
+    DeclareWar,
+    OfferPeace,
+    EstablishConsulate,
+    OpenEmbassy,
+    SignNonAggressionPact,
+    FormAlliance,
+    SendAid { amount: i32, locked: bool },
+    CancelAid,
+}
+
+/// Tracks UI selection state for diplomacy mode.
+#[derive(Resource, Default, Debug, Clone, Copy)]
+pub struct DiplomacySelection {
+    pub selected: Option<NationId>,
+}
+
+pub struct DiplomacyPlugin;
+
+impl Plugin for DiplomacyPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<DiplomacyState>()
+            .init_resource::<ForeignAidLedger>()
+            .init_resource::<DiplomaticOffers>()
+            .init_resource::<DiplomacySelection>()
+            .add_message::<DiplomaticOrder>()
+            .add_systems(
+                Update,
+                (
+                    sync_diplomatic_pairs,
+                    process_diplomatic_orders
+                        .run_if(resource_changed::<TurnSystem>)
+                        .run_if(|turn: Res<TurnSystem>| turn.phase == TurnPhase::Processing),
+                    apply_recurring_aid
+                        .run_if(resource_changed::<TurnSystem>)
+                        .run_if(|turn: Res<TurnSystem>| turn.phase == TurnPhase::PlayerTurn),
+                    decay_relationships
+                        .run_if(resource_changed::<TurnSystem>)
+                        .run_if(|turn: Res<TurnSystem>| turn.phase == TurnPhase::PlayerTurn),
+                )
+                    .run_if(in_state(AppState::InGame)),
+            );
+    }
+}
+
+fn sync_diplomatic_pairs(mut state: ResMut<DiplomacyState>, nations: Query<&NationId>) {
+    let ids: Vec<NationId> = nations.iter().copied().collect();
+    state.ensure_pairs(&ids);
+}
+
+fn process_diplomatic_orders(
+    mut orders: MessageReader<DiplomaticOrder>,
+    mut state: ResMut<DiplomacyState>,
+    mut ledger: ResMut<ForeignAidLedger>,
+    mut offers: ResMut<DiplomaticOffers>,
+    nations: Query<(Entity, &NationId, &Name)>,
+    mut treasuries: Query<&mut Treasury>,
+    mut log: MessageWriter<TerminalLogEvent>,
+) {
+    let (id_to_entity, id_to_name) = collect_nation_lookup(&nations);
+
+    for order in orders.read() {
+        if order.actor == order.target {
+            continue;
+        }
+
+        let Some(&actor_entity) = id_to_entity.get(&order.actor) else {
+            continue;
+        };
+        let Some(&target_entity) = id_to_entity.get(&order.target) else {
+            continue;
+        };
+
+        match &order.kind {
+            DiplomaticOrderKind::DeclareWar => {
+                let already_at_war = state
+                    .relation(order.actor, order.target)
+                    .map(|r| r.treaty.at_war)
+                    .unwrap_or(false);
+                if already_at_war {
+                    log.write(TerminalLogEvent {
+                        message: format!(
+                            "{} is already at war with {}.",
+                            display_name(&id_to_name, order.actor),
+                            display_name(&id_to_name, order.target)
+                        ),
+                    });
+                    continue;
+                }
+
+                state.set_treaty(order.actor, order.target, |t| {
+                    t.at_war = true;
+                    t.non_aggression_pact = false;
+                    t.alliance = false;
+                });
+                state.adjust_score(order.actor, order.target, -40);
+                ledger.cancel(order.actor, order.target);
+                log.write(TerminalLogEvent {
+                    message: format!(
+                        "{} has declared war on {}!",
+                        display_name(&id_to_name, order.actor),
+                        display_name(&id_to_name, order.target)
+                    ),
+                });
+            }
+            DiplomaticOrderKind::OfferPeace => {
+                let at_war = state
+                    .relation(order.actor, order.target)
+                    .map(|r| r.treaty.at_war)
+                    .unwrap_or(false);
+                if !at_war {
+                    log.write(TerminalLogEvent {
+                        message: format!(
+                            "{} and {} are not currently at war.",
+                            display_name(&id_to_name, order.actor),
+                            display_name(&id_to_name, order.target)
+                        ),
+                    });
+                    continue;
+                }
+
+                offers.push(DiplomaticOffer::new(
+                    order.actor,
+                    order.target,
+                    DiplomaticOfferKind::OfferPeace,
+                ));
+                log.write(TerminalLogEvent {
+                    message: format!(
+                        "{} offered peace to {}.",
+                        display_name(&id_to_name, order.actor),
+                        display_name(&id_to_name, order.target)
+                    ),
+                });
+            }
+            DiplomaticOrderKind::EstablishConsulate => {
+                if state
+                    .relation(order.actor, order.target)
+                    .map(|r| r.treaty.consulate)
+                    .unwrap_or(false)
+                {
+                    log.write(TerminalLogEvent {
+                        message: format!(
+                            "{} already maintains a consulate in {}.",
+                            display_name(&id_to_name, order.actor),
+                            display_name(&id_to_name, order.target)
+                        ),
+                    });
+                    continue;
+                }
+
+                let relation_score = state
+                    .relation(order.actor, order.target)
+                    .map(|r| r.score)
+                    .unwrap_or_default();
+                if relation_score < 0 {
+                    log.write(TerminalLogEvent {
+                        message: format!(
+                            "Relations with {} are too poor to open a consulate.",
+                            display_name(&id_to_name, order.target)
+                        ),
+                    });
+                    continue;
+                }
+
+                let afforded = {
+                    let mut treasury = match treasuries.get_mut(actor_entity) {
+                        Ok(t) => t,
+                        Err(_) => continue,
+                    };
+                    if treasury.available() < 500 {
+                        log.write(TerminalLogEvent {
+                            message: format!(
+                                "{} lacks the $500 needed for a consulate in {}.",
+                                display_name(&id_to_name, order.actor),
+                                display_name(&id_to_name, order.target)
+                            ),
+                        });
+                        false
+                    } else {
+                        treasury.subtract(500);
+                        true
+                    }
+                };
+                if !afforded {
+                    continue;
+                }
+
+                state.set_treaty(order.actor, order.target, |t| {
+                    t.consulate = true;
+                });
+                state.adjust_score(order.actor, order.target, 5);
+                log.write(TerminalLogEvent {
+                    message: format!(
+                        "{} established a consulate in {}.",
+                        display_name(&id_to_name, order.actor),
+                        display_name(&id_to_name, order.target)
+                    ),
+                });
+            }
+            DiplomaticOrderKind::OpenEmbassy => {
+                let relation_data = state.relation(order.actor, order.target).cloned();
+                let Some(relation) = relation_data else {
+                    continue;
+                };
+                if !relation.treaty.consulate {
+                    log.write(TerminalLogEvent {
+                        message: format!(
+                            "A consulate is required before opening an embassy in {}.",
+                            display_name(&id_to_name, order.target)
+                        ),
+                    });
+                    continue;
+                }
+                if relation.treaty.embassy {
+                    log.write(TerminalLogEvent {
+                        message: format!(
+                            "{} already has an embassy in {}.",
+                            display_name(&id_to_name, order.actor),
+                            display_name(&id_to_name, order.target)
+                        ),
+                    });
+                    continue;
+                }
+                if relation.score < 30 {
+                    log.write(TerminalLogEvent {
+                        message: format!(
+                            "Relations with {} must be Cordial (30) to open an embassy.",
+                            display_name(&id_to_name, order.target)
+                        ),
+                    });
+                    continue;
+                }
+
+                let afforded = {
+                    let mut treasury = match treasuries.get_mut(actor_entity) {
+                        Ok(t) => t,
+                        Err(_) => continue,
+                    };
+                    if treasury.available() < 5_000 {
+                        log.write(TerminalLogEvent {
+                            message: format!(
+                                "{} lacks the $5,000 needed for an embassy in {}.",
+                                display_name(&id_to_name, order.actor),
+                                display_name(&id_to_name, order.target)
+                            ),
+                        });
+                        false
+                    } else {
+                        treasury.subtract(5_000);
+                        true
+                    }
+                };
+                if !afforded {
+                    continue;
+                }
+
+                state.set_treaty(order.actor, order.target, |t| {
+                    t.embassy = true;
+                });
+                state.adjust_score(order.actor, order.target, 10);
+                log.write(TerminalLogEvent {
+                    message: format!(
+                        "{} opened an embassy in {}.",
+                        display_name(&id_to_name, order.actor),
+                        display_name(&id_to_name, order.target)
+                    ),
+                });
+            }
+            DiplomaticOrderKind::SignNonAggressionPact => {
+                let relation = state.relation(order.actor, order.target).cloned();
+                let Some(relation) = relation else { continue };
+                if relation.treaty.at_war {
+                    log.write(TerminalLogEvent {
+                        message: format!(
+                            "Cannot sign a pact while at war with {}.",
+                            display_name(&id_to_name, order.target)
+                        ),
+                    });
+                    continue;
+                }
+                if !relation.treaty.embassy {
+                    log.write(TerminalLogEvent {
+                        message: format!(
+                            "An embassy in {} is required before a pact can be signed.",
+                            display_name(&id_to_name, order.target)
+                        ),
+                    });
+                    continue;
+                }
+                if relation.treaty.non_aggression_pact {
+                    log.write(TerminalLogEvent {
+                        message: format!(
+                            "{} already has a pact with {}.",
+                            display_name(&id_to_name, order.actor),
+                            display_name(&id_to_name, order.target)
+                        ),
+                    });
+                    continue;
+                }
+
+                state.set_treaty(order.actor, order.target, |t| {
+                    t.non_aggression_pact = true;
+                });
+                state.adjust_score(order.actor, order.target, 8);
+                log.write(TerminalLogEvent {
+                    message: format!(
+                        "{} signed a non-aggression pact with {}.",
+                        display_name(&id_to_name, order.actor),
+                        display_name(&id_to_name, order.target)
+                    ),
+                });
+            }
+            DiplomaticOrderKind::FormAlliance => {
+                let relation = state.relation(order.actor, order.target).cloned();
+                let Some(relation) = relation else { continue };
+                if relation.treaty.at_war {
+                    log.write(TerminalLogEvent {
+                        message: format!(
+                            "Cannot ally while at war with {}.",
+                            display_name(&id_to_name, order.target)
+                        ),
+                    });
+                    continue;
+                }
+                if !relation.treaty.embassy {
+                    log.write(TerminalLogEvent {
+                        message: format!(
+                            "An embassy in {} is required before an alliance.",
+                            display_name(&id_to_name, order.target)
+                        ),
+                    });
+                    continue;
+                }
+                if relation.score < 40 {
+                    log.write(TerminalLogEvent {
+                        message: format!(
+                            "Relations with {} must be Warm (40) for an alliance.",
+                            display_name(&id_to_name, order.target)
+                        ),
+                    });
+                    continue;
+                }
+                if relation.treaty.alliance {
+                    log.write(TerminalLogEvent {
+                        message: format!(
+                            "{} already has an alliance with {}.",
+                            display_name(&id_to_name, order.actor),
+                            display_name(&id_to_name, order.target)
+                        ),
+                    });
+                    continue;
+                }
+
+                offers.push(DiplomaticOffer::new(
+                    order.actor,
+                    order.target,
+                    DiplomaticOfferKind::Alliance,
+                ));
+                log.write(TerminalLogEvent {
+                    message: format!(
+                        "{} proposed an alliance to {}.",
+                        display_name(&id_to_name, order.actor),
+                        display_name(&id_to_name, order.target)
+                    ),
+                });
+            }
+            DiplomaticOrderKind::SendAid { amount, locked } => {
+                if *amount <= 0 {
+                    continue;
+                }
+                let relation = state.relation(order.actor, order.target).cloned();
+                let Some(relation) = relation else { continue };
+                if relation.treaty.at_war {
+                    log.write(TerminalLogEvent {
+                        message: format!(
+                            "Cannot send aid while at war with {}.",
+                            display_name(&id_to_name, order.target)
+                        ),
+                    });
+                    continue;
+                }
+
+                let amount = *amount as i64;
+                let afforded = {
+                    let mut donor_treasury = match treasuries.get_mut(actor_entity) {
+                        Ok(t) => t,
+                        Err(_) => continue,
+                    };
+                    if donor_treasury.available() < amount {
+                        log.write(TerminalLogEvent {
+                            message: format!(
+                                "{} lacks ${} to fund aid for {}.",
+                                display_name(&id_to_name, order.actor),
+                                amount,
+                                display_name(&id_to_name, order.target)
+                            ),
+                        });
+                        false
+                    } else {
+                        donor_treasury.subtract(amount);
+                        true
+                    }
+                };
+                if !afforded {
+                    continue;
+                }
+
+                if let Ok(mut receiver_treasury) = treasuries.get_mut(target_entity) {
+                    receiver_treasury.add(amount);
+                }
+
+                let relation_bonus = (amount / 200).clamp(1, 10) as i32;
+                state.adjust_score(order.actor, order.target, relation_bonus);
+
+                if *locked {
+                    ledger.upsert(RecurringGrant {
+                        from: order.actor,
+                        to: order.target,
+                        amount: amount as i32,
+                    });
+                }
+
+                log.write(TerminalLogEvent {
+                    message: format!(
+                        "{} sent ${} in aid to {}{}.",
+                        display_name(&id_to_name, order.actor),
+                        amount,
+                        display_name(&id_to_name, order.target),
+                        if *locked { " (locked grant)" } else { "" }
+                    ),
+                });
+            }
+            DiplomaticOrderKind::CancelAid => {
+                if ledger.cancel(order.actor, order.target) {
+                    state.adjust_score(order.actor, order.target, -5);
+                    log.write(TerminalLogEvent {
+                        message: format!(
+                            "{} cancelled aid to {}.",
+                            display_name(&id_to_name, order.actor),
+                            display_name(&id_to_name, order.target)
+                        ),
+                    });
+                }
+            }
+        }
+    }
+}
+
+pub fn resolve_offer_response(
+    offer: DiplomaticOffer,
+    accept: bool,
+    state: &mut DiplomacyState,
+    ledger: &mut ForeignAidLedger,
+    nations: &Query<(Entity, &NationId, &Name)>,
+    treasuries: &mut Query<&mut Treasury>,
+    log: &mut MessageWriter<TerminalLogEvent>,
+) {
+    let (id_to_entity, id_to_name) = collect_nation_lookup(nations);
+
+    if accept {
+        match offer.kind {
+            DiplomaticOfferKind::OfferPeace => {
+                state.set_treaty(offer.from, offer.to, |t| {
+                    t.at_war = false;
+                    t.non_aggression_pact = false;
+                });
+                state.adjust_score(offer.from, offer.to, 15);
+                log.write(TerminalLogEvent {
+                    message: format!(
+                        "{} accepted peace with {}.",
+                        display_name(&id_to_name, offer.to),
+                        display_name(&id_to_name, offer.from)
+                    ),
+                });
+            }
+            DiplomaticOfferKind::Alliance => {
+                state.set_treaty(offer.from, offer.to, |t| {
+                    t.alliance = true;
+                    t.non_aggression_pact = true;
+                });
+                state.adjust_score(offer.from, offer.to, 12);
+                log.write(TerminalLogEvent {
+                    message: format!(
+                        "{} entered an alliance with {}.",
+                        display_name(&id_to_name, offer.to),
+                        display_name(&id_to_name, offer.from)
+                    ),
+                });
+            }
+            DiplomaticOfferKind::NonAggressionPact => {
+                state.set_treaty(offer.from, offer.to, |t| {
+                    t.non_aggression_pact = true;
+                });
+                state.adjust_score(offer.from, offer.to, 8);
+                log.write(TerminalLogEvent {
+                    message: format!(
+                        "{} accepted a non-aggression pact with {}.",
+                        display_name(&id_to_name, offer.to),
+                        display_name(&id_to_name, offer.from)
+                    ),
+                });
+            }
+            DiplomaticOfferKind::ForeignAid { amount, locked } => {
+                if let Some(&from_entity) = id_to_entity.get(&offer.from) {
+                    if let Ok(mut donor_treasury) = treasuries.get_mut(from_entity) {
+                        if donor_treasury.available() < amount as i64 {
+                            log.write(TerminalLogEvent {
+                                message: format!(
+                                    "{} could not afford the ${} aid promised to {}.",
+                                    display_name(&id_to_name, offer.from),
+                                    amount,
+                                    display_name(&id_to_name, offer.to)
+                                ),
+                            });
+                            return;
+                        }
+                        donor_treasury.subtract(amount as i64);
+                    }
+                }
+
+                if let Some(&to_entity) = id_to_entity.get(&offer.to) {
+                    if let Ok(mut receiver) = treasuries.get_mut(to_entity) {
+                        receiver.add(amount as i64);
+                    }
+                }
+
+                state.adjust_score(offer.from, offer.to, ((amount / 200).max(1)) as i32);
+
+                if locked {
+                    ledger.upsert(RecurringGrant {
+                        from: offer.from,
+                        to: offer.to,
+                        amount,
+                    });
+                }
+
+                log.write(TerminalLogEvent {
+                    message: format!(
+                        "{} received ${} in aid from {}{}.",
+                        display_name(&id_to_name, offer.to),
+                        amount,
+                        display_name(&id_to_name, offer.from),
+                        if locked { " (locked grant)" } else { "" }
+                    ),
+                });
+            }
+        }
+    } else {
+        match offer.kind {
+            DiplomaticOfferKind::OfferPeace => {
+                state.adjust_score(offer.from, offer.to, -10);
+                log.write(TerminalLogEvent {
+                    message: format!(
+                        "{} refused peace with {}.",
+                        display_name(&id_to_name, offer.to),
+                        display_name(&id_to_name, offer.from)
+                    ),
+                });
+            }
+            DiplomaticOfferKind::Alliance => {
+                state.adjust_score(offer.from, offer.to, -12);
+                log.write(TerminalLogEvent {
+                    message: format!(
+                        "{} declined an alliance proposed by {}.",
+                        display_name(&id_to_name, offer.to),
+                        display_name(&id_to_name, offer.from)
+                    ),
+                });
+            }
+            DiplomaticOfferKind::NonAggressionPact => {
+                state.adjust_score(offer.from, offer.to, -6);
+                log.write(TerminalLogEvent {
+                    message: format!(
+                        "{} rejected a non-aggression pact with {}.",
+                        display_name(&id_to_name, offer.to),
+                        display_name(&id_to_name, offer.from)
+                    ),
+                });
+            }
+            DiplomaticOfferKind::ForeignAid { .. } => {
+                state.adjust_score(offer.from, offer.to, -3);
+                log.write(TerminalLogEvent {
+                    message: format!(
+                        "{} declined aid from {}.",
+                        display_name(&id_to_name, offer.to),
+                        display_name(&id_to_name, offer.from)
+                    ),
+                });
+            }
+        }
+    }
+}
+
+fn apply_recurring_aid(
+    ledger: Res<ForeignAidLedger>,
+    mut state: ResMut<DiplomacyState>,
+    nations: Query<(Entity, &NationId, &Name)>,
+    mut treasuries: Query<&mut Treasury>,
+    mut log: MessageWriter<TerminalLogEvent>,
+) {
+    let (id_to_entity, id_to_name) = collect_nation_lookup(&nations);
+
+    let grants = ledger.all().to_vec();
+    for grant in grants {
+        let Some(&from_entity) = id_to_entity.get(&grant.from) else {
+            continue;
+        };
+        let Some(&to_entity) = id_to_entity.get(&grant.to) else {
+            continue;
+        };
+
+        let amount = grant.amount as i64;
+        let afforded = {
+            let mut donor_treasury = match treasuries.get_mut(from_entity) {
+                Ok(t) => t,
+                Err(_) => continue,
+            };
+            if donor_treasury.available() < amount {
+                log.write(TerminalLogEvent {
+                    message: format!(
+                        "{} could not afford the locked aid payment to {} (missing ${}).",
+                        display_name(&id_to_name, grant.from),
+                        display_name(&id_to_name, grant.to),
+                        amount
+                    ),
+                });
+                false
+            } else {
+                donor_treasury.subtract(amount);
+                true
+            }
+        };
+        if !afforded {
+            continue;
+        }
+
+        if let Ok(mut receiver) = treasuries.get_mut(to_entity) {
+            receiver.add(amount);
+        }
+
+        state.adjust_score(grant.from, grant.to, ((amount / 200).max(1)) as i32);
+
+        log.write(TerminalLogEvent {
+            message: format!(
+                "{} delivered ${} in locked aid to {}.",
+                display_name(&id_to_name, grant.from),
+                amount,
+                display_name(&id_to_name, grant.to)
+            ),
+        });
+    }
+}
+
+fn decay_relationships(mut state: ResMut<DiplomacyState>) {
+    for relation in state.relations.values_mut() {
+        if relation.treaty.at_war {
+            continue;
+        }
+        if relation.score > 0 {
+            relation.score -= 1;
+        } else if relation.score < 0 {
+            relation.score += 1;
+        }
+    }
+}
+
+fn display_name(names: &HashMap<NationId, String>, nation: NationId) -> String {
+    names
+        .get(&nation)
+        .cloned()
+        .unwrap_or_else(|| format!("Nation {}", nation.0))
+}
+
+fn collect_nation_lookup(
+    nations: &Query<(Entity, &NationId, &Name)>,
+) -> (HashMap<NationId, Entity>, HashMap<NationId, String>) {
+    let mut id_to_entity: HashMap<NationId, Entity> = HashMap::new();
+    let mut id_to_name: HashMap<NationId, String> = HashMap::new();
+    for (entity, nation_id, name) in nations.iter() {
+        id_to_entity.insert(*nation_id, entity);
+        id_to_name.insert(*nation_id, name.0.clone());
+    }
+    (id_to_entity, id_to_name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/diplomacy/tests.rs
+++ b/src/diplomacy/tests.rs
@@ -1,0 +1,345 @@
+use bevy::ecs::system::RunSystemOnce;
+use bevy::prelude::*;
+
+use super::{
+    DiplomacyState, DiplomaticOffer, DiplomaticOfferKind, DiplomaticOffers, DiplomaticOrder,
+    DiplomaticOrderKind, ForeignAidLedger, apply_recurring_aid, decay_relationships,
+    process_diplomatic_orders, resolve_offer_response, sync_diplomatic_pairs,
+};
+use crate::economy::{Name, NationId, Treasury};
+use crate::turn_system::{TurnPhase, TurnSystem};
+use crate::ui::logging::TerminalLogEvent;
+
+fn setup_world() -> World {
+    let mut world = World::new();
+    world.init_resource::<TurnSystem>();
+    world.init_resource::<Messages<TerminalLogEvent>>();
+    world.init_resource::<Messages<DiplomaticOrder>>();
+    world.insert_resource(DiplomacyState::default());
+    world.insert_resource(ForeignAidLedger::default());
+    world.insert_resource(DiplomaticOffers::default());
+    world
+}
+
+#[test]
+fn consulate_requires_funds_and_relations() {
+    let mut world = setup_world();
+
+    let player = world
+        .spawn((NationId(1), Name("Player".into()), Treasury::new(400)))
+        .id();
+    let _minor = world
+        .spawn((NationId(2), Name("Minor".into()), Treasury::new(0)))
+        .id();
+
+    world.resource_mut::<TurnSystem>().phase = TurnPhase::Processing;
+
+    // Ensure relations are tracked
+    let _ = world.run_system_once(sync_diplomatic_pairs);
+
+    // Attempt to open a consulate with insufficient funds (should fail)
+    {
+        let mut messages = world.resource_mut::<Messages<DiplomaticOrder>>();
+        messages.write(DiplomaticOrder {
+            actor: NationId(1),
+            target: NationId(2),
+            kind: DiplomaticOrderKind::EstablishConsulate,
+        });
+    }
+    let _ = world.run_system_once(process_diplomatic_orders);
+
+    // Treasury unchanged and no consulate flag set
+    let treasury = world.get::<Treasury>(player).unwrap();
+    assert_eq!(treasury.total(), 400);
+    assert!(
+        !world
+            .resource::<DiplomacyState>()
+            .relation(NationId(1), NationId(2))
+            .unwrap()
+            .treaty
+            .consulate
+    );
+
+    // Add funds and positive relations then try again
+    world.get_mut::<Treasury>(player).unwrap().add(200);
+    world
+        .resource_mut::<DiplomacyState>()
+        .adjust_score(NationId(1), NationId(2), 5);
+
+    {
+        let mut messages = world.resource_mut::<Messages<DiplomaticOrder>>();
+        messages.write(DiplomaticOrder {
+            actor: NationId(1),
+            target: NationId(2),
+            kind: DiplomaticOrderKind::EstablishConsulate,
+        });
+    }
+
+    let _ = world.run_system_once(process_diplomatic_orders);
+
+    let treasury = world.get::<Treasury>(player).unwrap();
+    assert_eq!(treasury.total(), 100); // 400 + 200 - 500 cost
+    assert!(
+        world
+            .resource::<DiplomacyState>()
+            .relation(NationId(1), NationId(2))
+            .unwrap()
+            .treaty
+            .consulate
+    );
+}
+
+#[test]
+fn recurring_aid_transfers_each_turn() {
+    let mut world = setup_world();
+
+    let donor = world
+        .spawn((NationId(1), Name("Donor".into()), Treasury::new(5_000)))
+        .id();
+    let recipient = world
+        .spawn((NationId(2), Name("Recipient".into()), Treasury::new(0)))
+        .id();
+
+    world.resource_mut::<TurnSystem>().phase = TurnPhase::Processing;
+
+    // Initialize relations and record the aid order
+    let _ = world.run_system_once(sync_diplomatic_pairs);
+
+    {
+        let mut messages = world.resource_mut::<Messages<DiplomaticOrder>>();
+        messages.write(DiplomaticOrder {
+            actor: NationId(1),
+            target: NationId(2),
+            kind: DiplomaticOrderKind::SendAid {
+                amount: 1_000,
+                locked: true,
+            },
+        });
+    }
+
+    let _ = world.run_system_once(process_diplomatic_orders);
+
+    // At start of next player turn apply recurring aid
+    world.resource_mut::<TurnSystem>().phase = TurnPhase::PlayerTurn;
+    let _ = world.run_system_once(
+        |ledger: Res<ForeignAidLedger>,
+         state: ResMut<DiplomacyState>,
+         nations: Query<(Entity, &NationId, &Name)>,
+         treasuries: Query<&mut Treasury>,
+         log: MessageWriter<TerminalLogEvent>| {
+            apply_recurring_aid(ledger, state, nations, treasuries, log);
+        },
+    );
+
+    // Verify funds moved and relation increased
+    let donor_treasury = world.get::<Treasury>(donor).unwrap();
+    let recipient_treasury = world.get::<Treasury>(recipient).unwrap();
+    assert_eq!(donor_treasury.total(), 3_000);
+    assert_eq!(recipient_treasury.total(), 2_000);
+
+    let before_score = world
+        .resource::<DiplomacyState>()
+        .relation(NationId(1), NationId(2))
+        .unwrap()
+        .score;
+    assert!(before_score >= 5);
+
+    // Decay should not drop wartime relations (already peace)
+    let _ = world.run_system_once(decay_relationships);
+    let after_score = world
+        .resource::<DiplomacyState>()
+        .relation(NationId(1), NationId(2))
+        .unwrap()
+        .score;
+    assert!(after_score <= before_score);
+}
+
+#[test]
+fn embassy_requires_consulate_and_relations() {
+    let mut world = setup_world();
+
+    world.spawn((NationId(1), Name("Empire".into()), Treasury::new(10_000)));
+    world.spawn((NationId(2), Name("Neighbor".into()), Treasury::new(0)));
+
+    world.resource_mut::<TurnSystem>().phase = TurnPhase::Processing;
+    let _ = world.run_system_once(sync_diplomatic_pairs);
+
+    // Attempt to open an embassy without a consulate
+    {
+        let mut messages = world.resource_mut::<Messages<DiplomaticOrder>>();
+        messages.write(DiplomaticOrder {
+            actor: NationId(1),
+            target: NationId(2),
+            kind: DiplomaticOrderKind::OpenEmbassy,
+        });
+    }
+    let _ = world.run_system_once(process_diplomatic_orders);
+
+    assert!(
+        !world
+            .resource::<DiplomacyState>()
+            .relation(NationId(1), NationId(2))
+            .unwrap()
+            .treaty
+            .embassy
+    );
+
+    // Grant consulate and relations then open embassy
+    world
+        .resource_mut::<DiplomacyState>()
+        .set_treaty(NationId(1), NationId(2), |t| t.consulate = true);
+    world
+        .resource_mut::<DiplomacyState>()
+        .adjust_score(NationId(1), NationId(2), 35);
+
+    {
+        let mut messages = world.resource_mut::<Messages<DiplomaticOrder>>();
+        messages.write(DiplomaticOrder {
+            actor: NationId(1),
+            target: NationId(2),
+            kind: DiplomaticOrderKind::OpenEmbassy,
+        });
+    }
+
+    let _ = world.run_system_once(process_diplomatic_orders);
+
+    assert!(
+        world
+            .resource::<DiplomacyState>()
+            .relation(NationId(1), NationId(2))
+            .unwrap()
+            .treaty
+            .embassy
+    );
+}
+
+#[test]
+fn offer_peace_creates_pending_offer() {
+    let mut world = setup_world();
+
+    world.spawn((NationId(1), Name("Player".into()), Treasury::new(1_000)));
+    world.spawn((NationId(2), Name("Foe".into()), Treasury::new(1_000)));
+
+    world.resource_mut::<TurnSystem>().phase = TurnPhase::Processing;
+    let _ = world.run_system_once(sync_diplomatic_pairs);
+
+    world
+        .resource_mut::<DiplomacyState>()
+        .set_treaty(NationId(1), NationId(2), |t| {
+            t.at_war = true;
+        });
+
+    {
+        let mut orders = world.resource_mut::<Messages<DiplomaticOrder>>();
+        orders.write(DiplomaticOrder {
+            actor: NationId(1),
+            target: NationId(2),
+            kind: DiplomaticOrderKind::OfferPeace,
+        });
+    }
+
+    let _ = world.run_system_once(process_diplomatic_orders);
+
+    let relation = world
+        .resource::<DiplomacyState>()
+        .relation(NationId(1), NationId(2))
+        .unwrap();
+    assert!(relation.treaty.at_war);
+    assert_eq!(world.resource::<DiplomaticOffers>().len(), 1);
+}
+
+#[test]
+fn accepting_peace_offer_sets_peace() {
+    let mut world = setup_world();
+
+    world.spawn((NationId(1), Name("Player".into()), Treasury::new(1_000)));
+    world.spawn((NationId(2), Name("Foe".into()), Treasury::new(1_000)));
+
+    world
+        .resource_mut::<DiplomacyState>()
+        .set_treaty(NationId(1), NationId(2), |t| {
+            t.at_war = true;
+        });
+
+    let offer = DiplomaticOffer::new(NationId(2), NationId(1), DiplomaticOfferKind::OfferPeace);
+
+    let _ = world.run_system_once(
+        move |mut state: ResMut<DiplomacyState>,
+              mut ledger: ResMut<ForeignAidLedger>,
+              nations: Query<(Entity, &NationId, &Name)>,
+              mut treasuries: Query<&mut Treasury>,
+              mut log: MessageWriter<TerminalLogEvent>| {
+            resolve_offer_response(
+                offer.clone(),
+                true,
+                &mut state,
+                &mut ledger,
+                &nations,
+                &mut treasuries,
+                &mut log,
+            );
+        },
+    );
+
+    let relation = world
+        .resource::<DiplomacyState>()
+        .relation(NationId(1), NationId(2))
+        .unwrap();
+    assert!(!relation.treaty.at_war);
+    assert!(relation.score >= 10);
+}
+
+#[test]
+fn accepting_locked_aid_creates_grant() {
+    let mut world = setup_world();
+
+    let donor = world
+        .spawn((NationId(1), Name("Donor".into()), Treasury::new(5_000)))
+        .id();
+    let recipient = world
+        .spawn((NationId(2), Name("Recipient".into()), Treasury::new(500)))
+        .id();
+
+    world
+        .resource_mut::<DiplomacyState>()
+        .set_treaty(NationId(1), NationId(2), |t| {
+            t.consulate = true;
+        });
+
+    let offer = DiplomaticOffer::new(
+        NationId(1),
+        NationId(2),
+        DiplomaticOfferKind::ForeignAid {
+            amount: 1_500,
+            locked: true,
+        },
+    );
+
+    let _ = world.run_system_once(
+        move |mut state: ResMut<DiplomacyState>,
+              mut ledger: ResMut<ForeignAidLedger>,
+              nations: Query<(Entity, &NationId, &Name)>,
+              mut treasuries: Query<&mut Treasury>,
+              mut log: MessageWriter<TerminalLogEvent>| {
+            resolve_offer_response(
+                offer.clone(),
+                true,
+                &mut state,
+                &mut ledger,
+                &nations,
+                &mut treasuries,
+                &mut log,
+            );
+        },
+    );
+
+    let donor_treasury = world.get::<Treasury>(donor).unwrap();
+    let recipient_treasury = world.get::<Treasury>(recipient).unwrap();
+    assert_eq!(donor_treasury.total(), 3_500);
+    assert_eq!(recipient_treasury.total(), 2_000);
+    assert!(
+        world
+            .resource::<ForeignAidLedger>()
+            .has_recurring(NationId(1), NationId(2))
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ use crate::civilians::{
     CivilianPlugin, advance_civilian_jobs, complete_improvement_jobs, reset_civilian_actions,
 };
 use crate::constants::{MAP_SIZE, TERRAIN_SEED, TILE_SIZE};
+use crate::diplomacy::DiplomacyPlugin;
 use crate::economy::allocation_systems;
 use crate::economy::production::{
     ConnectedProduction, calculate_connected_production, run_production,
@@ -44,6 +45,7 @@ pub mod city_rendering;
 pub mod civilians;
 pub mod constants;
 pub mod debug;
+pub mod diplomacy;
 pub mod economy;
 pub mod helpers;
 pub mod input;
@@ -328,6 +330,7 @@ pub fn app() -> App {
         TilemapBackend,
         // Game plugins (strategy baseline)
         TurnSystemPlugin,
+        DiplomacyPlugin,
         GameUIPlugin,
         InputPlugin,
         TransportRenderingPlugin,

--- a/src/ui/diplomacy.rs
+++ b/src/ui/diplomacy.rs
@@ -1,57 +1,526 @@
+use std::collections::HashMap;
+
 use bevy::prelude::*;
 
-use super::button_style::*;
-use crate::ui::mode::GameMode;
+use super::button_style::{
+    AccentButton, DangerButton, NORMAL_ACCENT, NORMAL_BUTTON, NORMAL_DANGER,
+};
+use crate::diplomacy::{
+    DiplomacySelection, DiplomacyState, DiplomaticOffer, DiplomaticOfferKind, DiplomaticOffers,
+    DiplomaticOrder, DiplomaticOrderKind, ForeignAidLedger, OfferId, resolve_offer_response,
+};
+use crate::economy::{Name, NationId, PlayerNation, Treasury};
+use crate::ui::logging::TerminalLogEvent;
+use crate::ui::mode::{GameMode, MapModeButton};
+
+const PANEL_BG: Color = Color::srgba(0.08, 0.09, 0.12, 0.92);
+const LIST_BG: Color = Color::srgba(0.11, 0.12, 0.15, 0.85);
+const DETAIL_BG: Color = Color::srgba(0.14, 0.15, 0.18, 0.75);
 
 #[derive(Component)]
 pub struct DiplomacyScreen;
+
+#[derive(Component)]
+struct DiplomacyNationButton {
+    nation: NationId,
+}
+
+#[derive(Component)]
+struct SelectedNationNameText;
+
+#[derive(Component)]
+struct SelectedRelationText;
+
+#[derive(Component)]
+struct SelectedTreatyText;
+
+#[derive(Component)]
+struct SelectedAidText;
+
+#[derive(Component)]
+struct DiplomacyActionButton {
+    action: DiplomaticAction,
+    target: NationId,
+}
+
+#[derive(Component)]
+struct PendingOffersContainer;
+
+#[derive(Component)]
+struct OfferResponseButton {
+    offer: OfferId,
+    accept: bool,
+}
+
+#[derive(Component)]
+struct PendingOfferList;
+
+#[derive(Clone, Copy)]
+enum DiplomaticAction {
+    DeclareWar,
+    OfferPeace,
+    Consulate,
+    Embassy,
+    Pact,
+    Alliance,
+    AidOnce(i32),
+    AidLocked(i32),
+    CancelAid,
+}
 
 pub struct DiplomacyUIPlugin;
 
 impl Plugin for DiplomacyUIPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(
-            OnEnter(GameMode::Diplomacy),
-            ensure_diplomacy_screen_visible,
-        )
-        .add_systems(OnExit(GameMode::Diplomacy), hide_diplomacy_screen);
+        app.add_systems(OnEnter(GameMode::Diplomacy), setup_diplomacy_screen)
+            .add_systems(OnExit(GameMode::Diplomacy), hide_diplomacy_screen)
+            .add_systems(
+                Update,
+                (
+                    ensure_selection_valid,
+                    update_nation_buttons,
+                    handle_nation_selection,
+                    update_detail_panel,
+                    update_action_buttons,
+                    handle_action_buttons,
+                    update_pending_offers,
+                    handle_offer_response_buttons,
+                )
+                    .chain()
+                    .run_if(in_state(GameMode::Diplomacy)),
+            );
     }
 }
 
-pub fn ensure_diplomacy_screen_visible(
+fn setup_diplomacy_screen(
     mut commands: Commands,
-    mut roots: Query<&mut Visibility, With<DiplomacyScreen>>,
+    mut screen_visibility: Query<&mut Visibility, With<DiplomacyScreen>>,
+    nations: Query<(Entity, &NationId, &Name)>,
+    player: Option<Res<PlayerNation>>,
+    mut selection: ResMut<DiplomacySelection>,
 ) {
-    if let Ok(mut vis) = roots.single_mut() {
-        *vis = Visibility::Visible;
+    if let Ok(mut visibility) = screen_visibility.single_mut() {
+        *visibility = Visibility::Visible;
         return;
     }
 
-    commands.spawn((
-        Node {
-            position_type: PositionType::Absolute,
-            left: Val::Px(0.0),
-            right: Val::Px(0.0),
-            top: Val::Px(0.0),
-            bottom: Val::Px(0.0),
-            padding: UiRect::all(Val::Px(16.0)),
-            flex_direction: FlexDirection::Column,
-            row_gap: Val::Px(12.0),
-            ..default()
-        },
-        BackgroundColor(Color::srgba(0.07, 0.05, 0.05, 0.92)),
-        DiplomacyScreen,
-        Visibility::Visible,
-        children![
-            (
-                Text::new("Diplomacy Mode (stub)"),
+    let player_entity = player.as_ref().map(|p| p.0);
+
+    let mut foreign_nations: Vec<(NationId, String)> = nations
+        .iter()
+        .filter_map(|(entity, id, name)| {
+            if Some(entity) == player_entity {
+                None
+            } else {
+                Some((*id, name.0.clone()))
+            }
+        })
+        .collect();
+    foreign_nations.sort_by(|a, b| a.1.cmp(&b.1));
+
+    if selection
+        .selected
+        .map(|sel| foreign_nations.iter().any(|(id, _)| *id == sel))
+        .unwrap_or(false)
+    {
+        // Keep existing selection
+    } else {
+        selection.selected = foreign_nations.first().map(|(id, _)| *id);
+    }
+
+    commands
+        .spawn((
+            Node {
+                position_type: PositionType::Absolute,
+                left: Val::Px(0.0),
+                right: Val::Px(0.0),
+                top: Val::Px(0.0),
+                bottom: Val::Px(0.0),
+                padding: UiRect::all(Val::Px(16.0)),
+                flex_direction: FlexDirection::Column,
+                row_gap: Val::Px(16.0),
+                ..default()
+            },
+            BackgroundColor(PANEL_BG),
+            DiplomacyScreen,
+        ))
+        .with_children(|root| {
+            root.spawn((
+                Text::new("Foreign Office"),
                 TextFont {
-                    font_size: 24.0,
+                    font_size: 28.0,
                     ..default()
                 },
-                TextColor(Color::srgb(0.95, 0.9, 1.0)),
-            ),
-            (
+                TextColor(Color::srgb(0.95, 0.92, 0.86)),
+            ));
+
+            root.spawn((
+                Text::new("Review relations and issue diplomatic overtures."),
+                TextFont {
+                    font_size: 16.0,
+                    ..default()
+                },
+                TextColor(Color::srgb(0.8, 0.85, 0.9)),
+            ));
+
+            root.spawn((Node {
+                flex_direction: FlexDirection::Row,
+                column_gap: Val::Px(16.0),
+                height: Val::Percent(100.0),
+                ..default()
+            },))
+                .with_children(|body| {
+                    // Nation list
+                    body.spawn((
+                        Node {
+                            width: Val::Percent(32.0),
+                            flex_direction: FlexDirection::Column,
+                            row_gap: Val::Px(8.0),
+                            padding: UiRect::all(Val::Px(12.0)),
+                            ..default()
+                        },
+                        BackgroundColor(LIST_BG),
+                    ))
+                    .with_children(|list| {
+                        list.spawn((
+                            Text::new("Nations"),
+                            TextFont {
+                                font_size: 18.0,
+                                ..default()
+                            },
+                            TextColor(Color::srgb(0.9, 0.92, 0.98)),
+                        ));
+
+                        for (nation, name) in &foreign_nations {
+                            list.spawn((
+                                Button,
+                                Node {
+                                    padding: UiRect::all(Val::Px(8.0)),
+                                    ..default()
+                                },
+                                BackgroundColor(NORMAL_BUTTON),
+                                DiplomacyNationButton { nation: *nation },
+                            ))
+                            .with_children(|button| {
+                                button.spawn((
+                                    Text::new(name.clone()),
+                                    TextFont {
+                                        font_size: 14.0,
+                                        ..default()
+                                    },
+                                    TextColor(Color::srgb(0.85, 0.9, 1.0)),
+                                ));
+                            });
+                        }
+
+                        if foreign_nations.is_empty() {
+                            list.spawn((
+                                Text::new("No foreign nations discovered yet."),
+                                TextFont {
+                                    font_size: 14.0,
+                                    ..default()
+                                },
+                                TextColor(Color::srgb(0.75, 0.75, 0.8)),
+                            ));
+                        }
+                    });
+
+                    // Detail panel
+                    body.spawn((
+                        Node {
+                            width: Val::Percent(68.0),
+                            flex_direction: FlexDirection::Column,
+                            row_gap: Val::Px(12.0),
+                            padding: UiRect::all(Val::Px(12.0)),
+                            ..default()
+                        },
+                        BackgroundColor(DETAIL_BG),
+                    ))
+                    .with_children(|detail| {
+                        detail.spawn((
+                            Text::new("Select a nation from the list."),
+                            TextFont {
+                                font_size: 22.0,
+                                ..default()
+                            },
+                            TextColor(Color::srgb(0.95, 0.96, 1.0)),
+                            SelectedNationNameText,
+                        ));
+
+                        detail.spawn((
+                            Text::new("Relationship: --"),
+                            TextFont {
+                                font_size: 16.0,
+                                ..default()
+                            },
+                            TextColor(Color::srgb(0.82, 0.88, 0.95)),
+                            SelectedRelationText,
+                        ));
+
+                        detail.spawn((
+                            Text::new("Treaties: none"),
+                            TextFont {
+                                font_size: 14.0,
+                                ..default()
+                            },
+                            TextColor(Color::srgb(0.78, 0.82, 0.88)),
+                            SelectedTreatyText,
+                        ));
+
+                        detail.spawn((
+                            Text::new("Locked aid: none"),
+                            TextFont {
+                                font_size: 14.0,
+                                ..default()
+                            },
+                            TextColor(Color::srgb(0.78, 0.82, 0.88)),
+                            SelectedAidText,
+                        ));
+
+                        // War / peace actions
+                        detail
+                            .spawn((Node {
+                                flex_direction: FlexDirection::Row,
+                                column_gap: Val::Px(8.0),
+                                ..default()
+                            },))
+                            .with_children(|row| {
+                                row.spawn((
+                                    Button,
+                                    Node {
+                                        padding: UiRect::all(Val::Px(8.0)),
+                                        ..default()
+                                    },
+                                    BackgroundColor(NORMAL_DANGER),
+                                    DiplomacyActionButton {
+                                        action: DiplomaticAction::DeclareWar,
+                                        target: NationId(0),
+                                    },
+                                    DangerButton,
+                                ))
+                                .with_children(|button| {
+                                    button.spawn((
+                                        Text::new("Declare War".to_string()),
+                                        TextFont {
+                                            font_size: 14.0,
+                                            ..default()
+                                        },
+                                        TextColor(Color::srgb(0.92, 0.95, 1.0)),
+                                    ));
+                                });
+
+                                row.spawn((
+                                    Button,
+                                    Node {
+                                        padding: UiRect::all(Val::Px(8.0)),
+                                        ..default()
+                                    },
+                                    BackgroundColor(NORMAL_BUTTON),
+                                    DiplomacyActionButton {
+                                        action: DiplomaticAction::OfferPeace,
+                                        target: NationId(0),
+                                    },
+                                ))
+                                .with_children(|button| {
+                                    button.spawn((
+                                        Text::new("Offer Peace".to_string()),
+                                        TextFont {
+                                            font_size: 14.0,
+                                            ..default()
+                                        },
+                                        TextColor(Color::srgb(0.92, 0.95, 1.0)),
+                                    ));
+                                });
+                            });
+
+                        // Diplomatic upgrades
+                        detail
+                            .spawn((Node {
+                                flex_direction: FlexDirection::Row,
+                                column_gap: Val::Px(8.0),
+                                ..default()
+                            },))
+                            .with_children(|row| {
+                                row.spawn((
+                                    Button,
+                                    Node {
+                                        padding: UiRect::all(Val::Px(8.0)),
+                                        ..default()
+                                    },
+                                    BackgroundColor(NORMAL_ACCENT),
+                                    DiplomacyActionButton {
+                                        action: DiplomaticAction::Consulate,
+                                        target: NationId(0),
+                                    },
+                                    AccentButton,
+                                ))
+                                .with_children(|button| {
+                                    button.spawn((
+                                        Text::new("Open Consulate ($500)".to_string()),
+                                        TextFont {
+                                            font_size: 14.0,
+                                            ..default()
+                                        },
+                                        TextColor(Color::srgb(0.92, 0.95, 1.0)),
+                                    ));
+                                });
+
+                                row.spawn((
+                                    Button,
+                                    Node {
+                                        padding: UiRect::all(Val::Px(8.0)),
+                                        ..default()
+                                    },
+                                    BackgroundColor(NORMAL_ACCENT),
+                                    DiplomacyActionButton {
+                                        action: DiplomaticAction::Embassy,
+                                        target: NationId(0),
+                                    },
+                                    AccentButton,
+                                ))
+                                .with_children(|button| {
+                                    button.spawn((
+                                        Text::new("Open Embassy ($5,000)".to_string()),
+                                        TextFont {
+                                            font_size: 14.0,
+                                            ..default()
+                                        },
+                                        TextColor(Color::srgb(0.92, 0.95, 1.0)),
+                                    ));
+                                });
+
+                                row.spawn((
+                                    Button,
+                                    Node {
+                                        padding: UiRect::all(Val::Px(8.0)),
+                                        ..default()
+                                    },
+                                    BackgroundColor(NORMAL_BUTTON),
+                                    DiplomacyActionButton {
+                                        action: DiplomaticAction::Pact,
+                                        target: NationId(0),
+                                    },
+                                ))
+                                .with_children(|button| {
+                                    button.spawn((
+                                        Text::new("Non-Aggression Pact".to_string()),
+                                        TextFont {
+                                            font_size: 14.0,
+                                            ..default()
+                                        },
+                                        TextColor(Color::srgb(0.92, 0.95, 1.0)),
+                                    ));
+                                });
+
+                                row.spawn((
+                                    Button,
+                                    Node {
+                                        padding: UiRect::all(Val::Px(8.0)),
+                                        ..default()
+                                    },
+                                    BackgroundColor(NORMAL_ACCENT),
+                                    DiplomacyActionButton {
+                                        action: DiplomaticAction::Alliance,
+                                        target: NationId(0),
+                                    },
+                                    AccentButton,
+                                ))
+                                .with_children(|button| {
+                                    button.spawn((
+                                        Text::new("Form Alliance".to_string()),
+                                        TextFont {
+                                            font_size: 14.0,
+                                            ..default()
+                                        },
+                                        TextColor(Color::srgb(0.92, 0.95, 1.0)),
+                                    ));
+                                });
+                            });
+
+                        // Aid controls
+                        detail
+                            .spawn((Node {
+                                flex_direction: FlexDirection::Row,
+                                column_gap: Val::Px(8.0),
+                                ..default()
+                            },))
+                            .with_children(|row| {
+                                row.spawn((
+                                    Button,
+                                    Node {
+                                        padding: UiRect::all(Val::Px(8.0)),
+                                        ..default()
+                                    },
+                                    BackgroundColor(NORMAL_ACCENT),
+                                    DiplomacyActionButton {
+                                        action: DiplomaticAction::AidOnce(500),
+                                        target: NationId(0),
+                                    },
+                                    AccentButton,
+                                ))
+                                .with_children(|button| {
+                                    button.spawn((
+                                        Text::new("Send $500 Aid".to_string()),
+                                        TextFont {
+                                            font_size: 14.0,
+                                            ..default()
+                                        },
+                                        TextColor(Color::srgb(0.92, 0.95, 1.0)),
+                                    ));
+                                });
+
+                                row.spawn((
+                                    Button,
+                                    Node {
+                                        padding: UiRect::all(Val::Px(8.0)),
+                                        ..default()
+                                    },
+                                    BackgroundColor(NORMAL_ACCENT),
+                                    DiplomacyActionButton {
+                                        action: DiplomaticAction::AidLocked(500),
+                                        target: NationId(0),
+                                    },
+                                    AccentButton,
+                                ))
+                                .with_children(|button| {
+                                    button.spawn((
+                                        Text::new("Lock $500 Aid".to_string()),
+                                        TextFont {
+                                            font_size: 14.0,
+                                            ..default()
+                                        },
+                                        TextColor(Color::srgb(0.92, 0.95, 1.0)),
+                                    ));
+                                });
+
+                                row.spawn((
+                                    Button,
+                                    Node {
+                                        padding: UiRect::all(Val::Px(8.0)),
+                                        ..default()
+                                    },
+                                    BackgroundColor(NORMAL_BUTTON),
+                                    DiplomacyActionButton {
+                                        action: DiplomaticAction::CancelAid,
+                                        target: NationId(0),
+                                    },
+                                ))
+                                .with_children(|button| {
+                                    button.spawn((
+                                        Text::new("Cancel Locked Aid".to_string()),
+                                        TextFont {
+                                            font_size: 14.0,
+                                            ..default()
+                                        },
+                                        TextColor(Color::srgb(0.92, 0.95, 1.0)),
+                                    ));
+                                });
+                            });
+                    });
+                });
+
+            // Back button
+            root.spawn((
                 Button,
                 Node {
                     position_type: PositionType::Absolute,
@@ -61,22 +530,592 @@ pub fn ensure_diplomacy_screen_visible(
                     ..default()
                 },
                 BackgroundColor(NORMAL_BUTTON),
-                crate::ui::mode::MapModeButton,
-                children![(
+                MapModeButton,
+            ))
+            .with_children(|button| {
+                button.spawn((
                     Text::new("Back to Map"),
                     TextFont {
                         font_size: 16.0,
                         ..default()
                     },
                     TextColor(Color::srgb(0.9, 0.9, 1.0)),
-                )],
-            ),
-        ],
-    ));
+                ));
+            });
+
+            root
+                .spawn((
+                    Node {
+                        flex_direction: FlexDirection::Column,
+                        row_gap: Val::Px(8.0),
+                        padding: UiRect::all(Val::Px(12.0)),
+                        width: Val::Percent(100.0),
+                        ..default()
+                    },
+                    BackgroundColor(LIST_BG),
+                    PendingOffersContainer,
+                ))
+                .with_children(|offers| {
+                    offers.spawn((
+                        Text::new("Pending Offers"),
+                        TextFont {
+                            font_size: 20.0,
+                            ..default()
+                        },
+                        TextColor(Color::srgb(0.92, 0.95, 1.0)),
+                    ));
+                    offers.spawn((
+                        Text::new("Foreign governments will occasionally send overtures that must be answered before the next turn."),
+                        TextFont {
+                            font_size: 14.0,
+                            ..default()
+                        },
+                        TextColor(Color::srgb(0.75, 0.8, 0.85)),
+                    ));
+                    offers
+                        .spawn((
+                            Node {
+                                flex_direction: FlexDirection::Column,
+                                row_gap: Val::Px(8.0),
+                                ..default()
+                            },
+                            PendingOfferList,
+                        ))
+                        .with_children(|list| {
+                            list.spawn((
+                                Text::new("No pending offers."),
+                                TextFont {
+                                    font_size: 14.0,
+                                    ..default()
+                                },
+                                TextColor(Color::srgb(0.8, 0.83, 0.9)),
+                            ));
+                        });
+                });
+        });
 }
 
-pub fn hide_diplomacy_screen(mut roots: Query<&mut Visibility, With<DiplomacyScreen>>) {
-    for mut vis in roots.iter_mut() {
-        *vis = Visibility::Hidden;
+fn ensure_selection_valid(
+    mut selection: ResMut<DiplomacySelection>,
+    player: Option<Res<PlayerNation>>,
+    nation_ids: Query<(Entity, &NationId)>,
+) {
+    let player_entity = player.map(|p| p.0);
+    let mut available: Vec<NationId> = Vec::new();
+    for (entity, nation) in nation_ids.iter() {
+        if Some(entity) == player_entity {
+            continue;
+        }
+        available.push(*nation);
+    }
+
+    if let Some(sel) = selection.selected
+        && !available.contains(&sel)
+    {
+        selection.selected = None;
+    }
+
+    if selection.selected.is_none() {
+        selection.selected = available.first().copied();
+    }
+}
+
+fn update_nation_buttons(
+    selection: Res<DiplomacySelection>,
+    state: Res<DiplomacyState>,
+    player: Option<Res<PlayerNation>>,
+    nation_ids: Query<&NationId>,
+    names: Query<(&NationId, &Name)>,
+    mut buttons: Query<(&DiplomacyNationButton, &mut Text, &mut BackgroundColor)>,
+) {
+    let player_id = player.and_then(|p| nation_ids.get(p.0).ok()).copied();
+
+    for (button, mut text, mut color) in buttons.iter_mut() {
+        let label = names
+            .iter()
+            .find(|(id, _)| **id == button.nation)
+            .map(|(_, name)| name.0.clone())
+            .unwrap_or_else(|| format!("Nation {}", button.nation.0));
+
+        let mut relation_line = label.clone();
+        if let Some(player_id) = player_id
+            && let Some(relation) = state.relation(player_id, button.nation)
+        {
+            relation_line = format!(
+                "{} — {} ({})",
+                label,
+                relation.score,
+                relation.band().label()
+            );
+        }
+
+        text.0 = relation_line;
+
+        if selection.selected == Some(button.nation) {
+            *color = BackgroundColor(NORMAL_ACCENT);
+        } else {
+            *color = BackgroundColor(NORMAL_BUTTON);
+        }
+    }
+}
+
+fn handle_nation_selection(
+    mut selection: ResMut<DiplomacySelection>,
+    mut buttons: Query<(&Interaction, &DiplomacyNationButton), Changed<Interaction>>,
+) {
+    for (interaction, button) in buttons.iter_mut() {
+        if *interaction == Interaction::Pressed {
+            selection.selected = Some(button.nation);
+        }
+    }
+}
+
+fn update_detail_panel(
+    selection: Res<DiplomacySelection>,
+    state: Res<DiplomacyState>,
+    ledger: Res<ForeignAidLedger>,
+    player: Option<Res<PlayerNation>>,
+    nation_ids: Query<&NationId>,
+    names: Query<(&NationId, &Name)>,
+    mut name_text: Query<&mut Text, With<SelectedNationNameText>>,
+    mut relation_text: Query<&mut Text, With<SelectedRelationText>>,
+    mut treaty_text: Query<&mut Text, With<SelectedTreatyText>>,
+    mut aid_text: Query<&mut Text, With<SelectedAidText>>,
+) {
+    let Some(selected) = selection.selected else {
+        if let Ok(mut text) = name_text.single_mut() {
+            text.0 = "No foreign nations selected".to_string();
+        }
+        if let Ok(mut text) = relation_text.single_mut() {
+            text.0 = "Relationship: --".to_string();
+        }
+        if let Ok(mut text) = treaty_text.single_mut() {
+            text.0 = "Treaties: none".to_string();
+        }
+        if let Ok(mut text) = aid_text.single_mut() {
+            text.0 = "Locked aid: none".to_string();
+        }
+        return;
+    };
+
+    let player_id = player.and_then(|p| nation_ids.get(p.0).ok()).copied();
+
+    let selected_name = names
+        .iter()
+        .find(|(id, _)| **id == selected)
+        .map(|(_, name)| name.0.clone())
+        .unwrap_or_else(|| format!("Nation {}", selected.0));
+
+    if let Ok(mut text) = name_text.single_mut() {
+        text.0 = selected_name.clone();
+    }
+
+    let relation = player_id.and_then(|pid| state.relation(pid, selected));
+    if let Ok(mut text) = relation_text.single_mut() {
+        if let Some(relation) = relation {
+            text.0 = format!(
+                "Relationship: {} ({})",
+                relation.score,
+                relation.band().label()
+            );
+        } else {
+            text.0 = "Relationship: unknown".to_string();
+        }
+    }
+
+    if let Ok(mut text) = treaty_text.single_mut() {
+        if let Some(relation) = relation {
+            let mut flags = Vec::new();
+            if relation.treaty.at_war {
+                flags.push("At war");
+            } else {
+                flags.push("At peace");
+            }
+            if relation.treaty.consulate {
+                flags.push("Consulate");
+            }
+            if relation.treaty.embassy {
+                flags.push("Embassy");
+            }
+            if relation.treaty.non_aggression_pact {
+                flags.push("Pact");
+            }
+            if relation.treaty.alliance {
+                flags.push("Alliance");
+            }
+            text.0 = format!("Treaties: {}", flags.join(", "));
+        } else {
+            text.0 = "Treaties: none".to_string();
+        }
+    }
+
+    if let Ok(mut text) = aid_text.single_mut() {
+        if let Some(player_id) = player_id {
+            if let Some(grant) = ledger
+                .all()
+                .iter()
+                .find(|g| g.from == player_id && g.to == selected)
+            {
+                text.0 = format!("Locked aid: ${} per turn", grant.amount);
+            } else {
+                text.0 = "Locked aid: none".to_string();
+            }
+        } else {
+            text.0 = "Locked aid: unavailable".to_string();
+        }
+    }
+}
+
+fn update_action_buttons(
+    selection: Res<DiplomacySelection>,
+    state: Res<DiplomacyState>,
+    ledger: Res<ForeignAidLedger>,
+    player: Option<Res<PlayerNation>>,
+    nation_ids: Query<&NationId>,
+    mut buttons: Query<(&mut DiplomacyActionButton, &mut Visibility)>,
+) {
+    let Some(selected) = selection.selected else {
+        for (_, mut visibility) in buttons.iter_mut() {
+            *visibility = Visibility::Hidden;
+        }
+        return;
+    };
+
+    let player_id = if let Some(player) = player {
+        nation_ids.get(player.0).ok().copied()
+    } else {
+        None
+    };
+
+    for (mut button, mut visibility) in buttons.iter_mut() {
+        button.target = selected;
+        let Some(player_id) = player_id else {
+            *visibility = Visibility::Hidden;
+            continue;
+        };
+        let Some(relation) = state.relation(player_id, selected) else {
+            *visibility = Visibility::Hidden;
+            continue;
+        };
+
+        let show = match button.action {
+            DiplomaticAction::DeclareWar => !relation.treaty.at_war,
+            DiplomaticAction::OfferPeace => relation.treaty.at_war,
+            DiplomaticAction::Consulate => !relation.treaty.consulate && !relation.treaty.at_war,
+            DiplomaticAction::Embassy => {
+                relation.treaty.consulate && !relation.treaty.embassy && !relation.treaty.at_war
+            }
+            DiplomaticAction::Pact => relation.treaty.embassy && !relation.treaty.at_war,
+            DiplomaticAction::Alliance => relation.treaty.embassy && !relation.treaty.at_war,
+            DiplomaticAction::AidOnce(_) => !relation.treaty.at_war,
+            DiplomaticAction::AidLocked(_) => !relation.treaty.at_war,
+            DiplomaticAction::CancelAid => ledger.has_recurring(player_id, selected),
+        };
+
+        *visibility = if show {
+            Visibility::Visible
+        } else {
+            Visibility::Hidden
+        };
+    }
+}
+
+fn handle_action_buttons(
+    selection: Res<DiplomacySelection>,
+    player: Option<Res<PlayerNation>>,
+    nation_ids: Query<&NationId>,
+    mut buttons: Query<(&Interaction, &DiplomacyActionButton), Changed<Interaction>>,
+    mut orders: MessageWriter<DiplomaticOrder>,
+) {
+    let Some(selected) = selection.selected else {
+        return;
+    };
+
+    let player_id = match player.and_then(|p| nation_ids.get(p.0).ok()).copied() {
+        Some(id) => id,
+        None => return,
+    };
+
+    for (interaction, button) in buttons.iter_mut() {
+        if *interaction != Interaction::Pressed {
+            continue;
+        }
+
+        if button.target != selected {
+            continue;
+        }
+
+        let order = match button.action {
+            DiplomaticAction::DeclareWar => DiplomaticOrder {
+                actor: player_id,
+                target: selected,
+                kind: DiplomaticOrderKind::DeclareWar,
+            },
+            DiplomaticAction::OfferPeace => DiplomaticOrder {
+                actor: player_id,
+                target: selected,
+                kind: DiplomaticOrderKind::OfferPeace,
+            },
+            DiplomaticAction::Consulate => DiplomaticOrder {
+                actor: player_id,
+                target: selected,
+                kind: DiplomaticOrderKind::EstablishConsulate,
+            },
+            DiplomaticAction::Embassy => DiplomaticOrder {
+                actor: player_id,
+                target: selected,
+                kind: DiplomaticOrderKind::OpenEmbassy,
+            },
+            DiplomaticAction::Pact => DiplomaticOrder {
+                actor: player_id,
+                target: selected,
+                kind: DiplomaticOrderKind::SignNonAggressionPact,
+            },
+            DiplomaticAction::Alliance => DiplomaticOrder {
+                actor: player_id,
+                target: selected,
+                kind: DiplomaticOrderKind::FormAlliance,
+            },
+            DiplomaticAction::AidOnce(amount) => DiplomaticOrder {
+                actor: player_id,
+                target: selected,
+                kind: DiplomaticOrderKind::SendAid {
+                    amount,
+                    locked: false,
+                },
+            },
+            DiplomaticAction::AidLocked(amount) => DiplomaticOrder {
+                actor: player_id,
+                target: selected,
+                kind: DiplomaticOrderKind::SendAid {
+                    amount,
+                    locked: true,
+                },
+            },
+            DiplomaticAction::CancelAid => DiplomaticOrder {
+                actor: player_id,
+                target: selected,
+                kind: DiplomaticOrderKind::CancelAid,
+            },
+        };
+
+        orders.write(order);
+    }
+}
+
+fn update_pending_offers(
+    offers: Res<DiplomaticOffers>,
+    player: Option<Res<PlayerNation>>,
+    nation_ids: Query<&NationId>,
+    nations: Query<(Entity, &NationId, &Name)>,
+    children: Query<&Children>,
+    list_query: Query<Entity, With<PendingOfferList>>,
+    mut commands: Commands,
+) {
+    let Some(list_entity) = list_query.iter().next() else {
+        return;
+    };
+
+    let Some(player) = player else {
+        return;
+    };
+
+    let Ok(player_id) = nation_ids.get(player.0) else {
+        return;
+    };
+
+    if !offers.is_changed() && !player.is_changed() {
+        return;
+    }
+
+    let mut names: HashMap<NationId, String> = HashMap::new();
+    for (_, id, name) in nations.iter() {
+        names.insert(*id, name.0.clone());
+    }
+
+    let relevant: Vec<DiplomaticOffer> = offers.iter_for(*player_id).cloned().collect();
+
+    clear_children_recursive(list_entity, &mut commands, &children);
+
+    commands.entity(list_entity).with_children(|list| {
+        if relevant.is_empty() {
+            list.spawn((
+                Text::new("No pending offers."),
+                TextFont {
+                    font_size: 14.0,
+                    ..default()
+                },
+                TextColor(Color::srgb(0.8, 0.83, 0.9)),
+            ));
+        } else {
+            for offer in relevant {
+                let summary = describe_offer(&offer, &names);
+                list.spawn((
+                    Node {
+                        flex_direction: FlexDirection::Column,
+                        row_gap: Val::Px(6.0),
+                        padding: UiRect::all(Val::Px(8.0)),
+                        ..default()
+                    },
+                    BackgroundColor(DETAIL_BG),
+                ))
+                .with_children(|entry| {
+                    entry.spawn((
+                        Text::new(summary),
+                        TextFont {
+                            font_size: 14.0,
+                            ..default()
+                        },
+                        TextColor(Color::srgb(0.92, 0.95, 1.0)),
+                    ));
+
+                    entry
+                        .spawn((Node {
+                            flex_direction: FlexDirection::Row,
+                            column_gap: Val::Px(8.0),
+                            ..default()
+                        },))
+                        .with_children(|row| {
+                            row.spawn((
+                                Button,
+                                Node {
+                                    padding: UiRect::all(Val::Px(6.0)),
+                                    ..default()
+                                },
+                                BackgroundColor(NORMAL_ACCENT),
+                                OfferResponseButton {
+                                    offer: offer.id,
+                                    accept: true,
+                                },
+                                AccentButton,
+                            ))
+                            .with_children(|button| {
+                                button.spawn((
+                                    Text::new("Accept"),
+                                    TextFont {
+                                        font_size: 13.0,
+                                        ..default()
+                                    },
+                                    TextColor(Color::srgb(0.92, 0.95, 1.0)),
+                                ));
+                            });
+
+                            row.spawn((
+                                Button,
+                                Node {
+                                    padding: UiRect::all(Val::Px(6.0)),
+                                    ..default()
+                                },
+                                BackgroundColor(NORMAL_DANGER),
+                                OfferResponseButton {
+                                    offer: offer.id,
+                                    accept: false,
+                                },
+                                DangerButton,
+                            ))
+                            .with_children(|button| {
+                                button.spawn((
+                                    Text::new("Decline"),
+                                    TextFont {
+                                        font_size: 13.0,
+                                        ..default()
+                                    },
+                                    TextColor(Color::srgb(0.92, 0.95, 1.0)),
+                                ));
+                            });
+                        });
+                });
+            }
+        }
+    });
+}
+
+fn handle_offer_response_buttons(
+    mut interactions: Query<
+        (&Interaction, &OfferResponseButton),
+        (Changed<Interaction>, With<Button>),
+    >,
+    mut offers: ResMut<DiplomaticOffers>,
+    mut state: ResMut<DiplomacyState>,
+    mut ledger: ResMut<ForeignAidLedger>,
+    nations: Query<(Entity, &NationId, &Name)>,
+    mut treasuries: Query<&mut Treasury>,
+    mut log: MessageWriter<TerminalLogEvent>,
+) {
+    for (interaction, button) in interactions.iter_mut() {
+        if *interaction != Interaction::Pressed {
+            continue;
+        }
+
+        let Some(offer) = offers.take(button.offer) else {
+            continue;
+        };
+
+        resolve_offer_response(
+            offer,
+            button.accept,
+            &mut state,
+            &mut ledger,
+            &nations,
+            &mut treasuries,
+            &mut log,
+        );
+    }
+}
+
+fn clear_children_recursive(entity: Entity, commands: &mut Commands, children: &Query<&Children>) {
+    if let Ok(child_list) = children.get(entity) {
+        for child in child_list.iter() {
+            clear_children_recursive(child, commands, children);
+            commands.entity(child).despawn();
+        }
+    }
+}
+
+fn describe_offer(offer: &DiplomaticOffer, names: &HashMap<NationId, String>) -> String {
+    match &offer.kind {
+        DiplomaticOfferKind::OfferPeace => {
+            format!("{} requests peace.", format_name(names, offer.from))
+        }
+        DiplomaticOfferKind::Alliance => {
+            format!(
+                "{} proposes a mutual alliance.",
+                format_name(names, offer.from)
+            )
+        }
+        DiplomaticOfferKind::NonAggressionPact => {
+            format!(
+                "{} seeks a non-aggression pact.",
+                format_name(names, offer.from)
+            )
+        }
+        DiplomaticOfferKind::ForeignAid { amount, locked } => {
+            if *locked {
+                format!(
+                    "{} offers a locked ${} annual grant.",
+                    format_name(names, offer.from),
+                    amount
+                )
+            } else {
+                format!(
+                    "{} offers a one-time aid payment of ${}.",
+                    format_name(names, offer.from),
+                    amount
+                )
+            }
+        }
+    }
+}
+
+fn format_name(names: &HashMap<NationId, String>, nation: NationId) -> String {
+    names
+        .get(&nation)
+        .cloned()
+        .unwrap_or_else(|| format!("Nation {}", nation.0))
+}
+
+fn hide_diplomacy_screen(mut screens: Query<&mut Visibility, With<DiplomacyScreen>>) {
+    for mut visibility in screens.iter_mut() {
+        *visibility = Visibility::Hidden;
     }
 }


### PR DESCRIPTION
## Summary
- queue diplomatic offers via a new resource and resolve acceptance/decline outcomes alongside existing turn systems
- surface pending offers in the diplomacy UI so the player can accept or reject proposals during their turn
- block end-turn input while unresolved offers remain and add unit tests covering offer handling and gating

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68f238832c5c832fa54073fc704622a5