### PR TITLE
Add transport capacity tracking and UI interactions

### DIFF
--- a/src/civilians/systems.rs
+++ b/src/civilians/systems.rs
@@ -8,8 +8,8 @@ use super::types::{
     ActionTurn, Civilian, CivilianJob, CivilianOrder, CivilianOrderKind, PreviousPosition,
 };
 use crate::economy::treasury::Treasury;
-use crate::rendering::MapVisualFor;
 use crate::province::{Province, TileProvince};
+use crate::rendering::MapVisualFor;
 use crate::turn_system::TurnSystem;
 use crate::ui::logging::TerminalLogEvent;
 

--- a/src/economy/nation.rs
+++ b/src/economy/nation.rs
@@ -185,9 +185,18 @@ mod tests {
         assert_eq!(player3.entity(), nation3);
 
         // Verify the IDs are correct
-        assert_eq!(world.entity(player1.entity()).get::<NationId>().unwrap().0, 1);
-        assert_eq!(world.entity(player2.entity()).get::<NationId>().unwrap().0, 2);
-        assert_eq!(world.entity(player3.entity()).get::<NationId>().unwrap().0, 3);
+        assert_eq!(
+            world.entity(player1.entity()).get::<NationId>().unwrap().0,
+            1
+        );
+        assert_eq!(
+            world.entity(player2.entity()).get::<NationId>().unwrap().0,
+            2
+        );
+        assert_eq!(
+            world.entity(player3.entity()).get::<NationId>().unwrap().0,
+            3
+        );
     }
 
     #[test]

--- a/src/economy/transport/metrics.rs
+++ b/src/economy/transport/metrics.rs
@@ -1,0 +1,224 @@
+use bevy::prelude::*;
+use std::collections::HashMap;
+
+use crate::economy::{
+    allocation::Allocations,
+    goods::Good,
+    production::{BuildingKind, Buildings, ProductionChoice},
+    transport::{
+        AllocationSlot, CapacitySnapshot, DemandEntry, TransportAllocations, TransportCapacity,
+        TransportCommodity, TransportDemandSnapshot,
+    },
+    workforce::Workforce,
+};
+
+use super::types::{Depot, Port};
+
+/// Base capacity contributed by each connected depot.
+const DEPOT_CAPACITY: u32 = 6;
+/// Base capacity contributed by each connected port.
+const PORT_CAPACITY: u32 = 8;
+
+/// Recalculate transport capacity totals from connected depots and ports.
+pub fn update_transport_capacity(
+    mut capacity: ResMut<TransportCapacity>,
+    depots: Query<&Depot>,
+    ports: Query<&Port>,
+) {
+    let mut totals: HashMap<Entity, CapacitySnapshot> = HashMap::new();
+
+    for depot in depots.iter().filter(|d| d.connected) {
+        let entry = totals.entry(depot.owner).or_default();
+        entry.total += DEPOT_CAPACITY;
+    }
+
+    for port in ports.iter().filter(|p| p.connected) {
+        let entry = totals.entry(port.owner).or_default();
+        entry.total += PORT_CAPACITY;
+    }
+
+    capacity
+        .nations
+        .retain(|nation, _| totals.contains_key(nation));
+
+    for (nation, totals_snapshot) in totals {
+        let snapshot = capacity.snapshot_mut(nation);
+        snapshot.total = totals_snapshot.total;
+        snapshot.used = snapshot.used.min(snapshot.total);
+    }
+}
+
+/// Message emitted from UI sliders requesting a new allocation level.
+#[derive(Message, Debug, Clone, Copy)]
+pub struct TransportAdjustAllocation {
+    pub nation: Entity,
+    pub commodity: TransportCommodity,
+    pub requested: u32,
+}
+
+/// Apply allocation adjustments while respecting total capacity.
+pub fn apply_transport_allocations(
+    mut capacity: ResMut<TransportCapacity>,
+    mut allocations: ResMut<TransportAllocations>,
+    mut requests: MessageReader<TransportAdjustAllocation>,
+) {
+    for request in requests.read() {
+        let nation_alloc = allocations.ensure_nation(request.nation);
+        let slot = nation_alloc.slot_mut(request.commodity);
+        slot.requested = request.requested;
+    }
+
+    // Recompute granted totals per nation.
+    for (nation, nation_alloc) in allocations.nations.iter_mut() {
+        let mut remaining = capacity.snapshot(*nation).total;
+        for commodity in TransportCommodity::ORDERED.iter() {
+            if let Some(slot) = nation_alloc.commodities.get_mut(commodity) {
+                let granted = slot.requested.min(remaining);
+                slot.granted = granted;
+                remaining = remaining.saturating_sub(granted);
+            }
+        }
+        capacity.snapshot_mut(*nation).used = capacity.snapshot(*nation).total - remaining;
+    }
+}
+
+/// Helper describing input requirements for one unit of production.
+fn inputs_for_output(
+    kind: BuildingKind,
+    choice: ProductionChoice,
+    _output: Good,
+) -> Vec<(Good, u32)> {
+    match kind {
+        BuildingKind::TextileMill => match choice {
+            ProductionChoice::UseCotton => vec![(Good::Cotton, 2)],
+            ProductionChoice::UseWool => vec![(Good::Wool, 2)],
+            _ => vec![(Good::Cotton, 2)],
+        },
+        BuildingKind::LumberMill => vec![(Good::Timber, 2)],
+        BuildingKind::SteelMill => vec![(Good::Iron, 1), (Good::Coal, 1)],
+        BuildingKind::FoodProcessingCenter => {
+            let meat = match choice {
+                ProductionChoice::UseFish => Good::Fish,
+                _ => Good::Livestock,
+            };
+            // Output is in canned food units (2 per batch)
+            vec![(Good::Grain, 2), (Good::Fruit, 1), (meat, 1)]
+        }
+        BuildingKind::Capitol | BuildingKind::TradeSchool | BuildingKind::PowerPlant => vec![],
+    }
+}
+
+/// Update supply/demand snapshot for transport UI.
+pub fn update_transport_demand_snapshot(
+    connected_production: Res<crate::economy::production::ConnectedProduction>,
+    workforces: Query<(Entity, &Workforce)>,
+    allocations: Query<(Entity, &Allocations, Option<&Buildings>)>,
+    mut snapshot: ResMut<TransportDemandSnapshot>,
+) {
+    snapshot.nations.clear();
+
+    // Supply from connected production
+    for (nation, resources) in connected_production.0.iter() {
+        let entries = snapshot.nations.entry(*nation).or_insert_with(HashMap::new);
+        for commodity in TransportCommodity::ORDERED.iter() {
+            let mut supply = 0u32;
+            for resource_type in commodity.resource_types() {
+                if let Some((_, output)) = resources.get(resource_type) {
+                    supply += *output;
+                }
+            }
+            if supply > 0 {
+                entries
+                    .entry(*commodity)
+                    .or_insert_with(DemandEntry::default)
+                    .supply = supply;
+            }
+        }
+    }
+
+    // Demand from workforce (food)
+    for (entity, workforce) in workforces.iter() {
+        let entries = snapshot.nations.entry(entity).or_insert_with(HashMap::new);
+        for (index, _worker) in workforce.workers.iter().enumerate() {
+            let commodity = match index % 3 {
+                0 => TransportCommodity::Grain,
+                1 => TransportCommodity::Fruit,
+                _ => TransportCommodity::Meat,
+            };
+            entries
+                .entry(commodity)
+                .or_insert_with(DemandEntry::default)
+                .demand += 1;
+        }
+    }
+
+    // Demand from production allocations
+    for (nation, alloc, maybe_buildings) in allocations.iter() {
+        let entries = snapshot.nations.entry(nation).or_insert_with(HashMap::new);
+
+        for ((_, output_good), reservations) in alloc.production.iter() {
+            let Some(buildings) = maybe_buildings else {
+                continue;
+            };
+
+            let building_kind = match output_good {
+                Good::Fabric | Good::Cloth => BuildingKind::TextileMill,
+                Good::Paper | Good::Lumber => BuildingKind::LumberMill,
+                Good::Steel => BuildingKind::SteelMill,
+                Good::CannedFood => BuildingKind::FoodProcessingCenter,
+                _ => continue,
+            };
+
+            let building = buildings.get(building_kind);
+            if building.is_none() {
+                continue;
+            }
+
+            let choice = match building_kind {
+                BuildingKind::TextileMill => ProductionChoice::UseCotton,
+                BuildingKind::FoodProcessingCenter => ProductionChoice::UseLivestock,
+                _ => ProductionChoice::UseCotton,
+            };
+
+            let inputs = inputs_for_output(building_kind, choice, *output_good);
+            let units = reservations.len() as u32;
+
+            for (good, amount_per_unit) in inputs {
+                if let Some(commodity) = TransportCommodity::from_good(good) {
+                    entries
+                        .entry(commodity)
+                        .or_insert_with(DemandEntry::default)
+                        .demand += amount_per_unit * units;
+                }
+            }
+        }
+    }
+}
+
+/// Provide quick access to allocation slots for UI rendering.
+pub fn transport_slot(
+    allocations: &TransportAllocations,
+    nation: Entity,
+    commodity: TransportCommodity,
+) -> AllocationSlot {
+    allocations.slot(nation, commodity)
+}
+
+/// Provide quick access to demand entries for UI rendering.
+pub fn transport_demand(
+    snapshot: &TransportDemandSnapshot,
+    nation: Entity,
+    commodity: TransportCommodity,
+) -> DemandEntry {
+    snapshot
+        .nations
+        .get(&nation)
+        .and_then(|map| map.get(&commodity))
+        .copied()
+        .unwrap_or_default()
+}
+
+/// Provide quick access to capacity snapshot for UI rendering.
+pub fn transport_capacity(capacity: &TransportCapacity, nation: Entity) -> CapacitySnapshot {
+    capacity.snapshot(nation)
+}

--- a/src/economy/transport/mod.rs
+++ b/src/economy/transport/mod.rs
@@ -2,6 +2,20 @@
 pub mod types;
 pub use types::{Depot, ImprovementKind, Port, RailConstruction, Rails, Roads, ordered_edge};
 
+// Transport state (capacity, allocations, demand)
+pub mod state;
+pub use state::{
+    AllocationSlot, CapacitySnapshot, DemandEntry, NationAllocations, TransportAllocations,
+    TransportCapacity, TransportCommodity, TransportDemandSnapshot,
+};
+
+// Derived metrics and logic
+pub mod metrics;
+pub use metrics::{
+    TransportAdjustAllocation, apply_transport_allocations, transport_capacity, transport_demand,
+    transport_slot, update_transport_capacity, update_transport_demand_snapshot,
+};
+
 // Messages
 pub mod messages;
 pub use messages::{PlaceImprovement, RecomputeConnectivity};

--- a/src/economy/transport/state.rs
+++ b/src/economy/transport/state.rs
@@ -1,0 +1,205 @@
+use bevy::prelude::*;
+use std::collections::HashMap;
+
+use crate::{economy::goods::Good, resources::ResourceType};
+
+/// Aggregated commodity buckets shown on the transport screen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect)]
+pub enum TransportCommodity {
+    Grain,
+    Fruit,
+    Fiber, // Cotton & Wool
+    Meat,  // Livestock & Fish
+    Timber,
+    Coal,
+    Iron,
+    Precious, // Gold & Gems
+    Oil,
+    Fabric,
+    Lumber,
+    Paper,
+    Steel,
+    Fuel,
+    Clothing,
+    Furniture,
+    Hardware,
+    Armaments,
+    CannedFood,
+    Horses,
+}
+
+impl TransportCommodity {
+    /// Goods that fall under this commodity bucket.
+    pub fn goods(self) -> &'static [Good] {
+        use TransportCommodity::*;
+        match self {
+            Grain => &[Good::Grain],
+            Fruit => &[Good::Fruit],
+            Fiber => &[Good::Cotton, Good::Wool],
+            Meat => &[Good::Livestock, Good::Fish],
+            Timber => &[Good::Timber],
+            Coal => &[Good::Coal],
+            Iron => &[Good::Iron],
+            Precious => &[Good::Gold, Good::Gems],
+            Oil => &[Good::Oil],
+            Fabric => &[Good::Fabric, Good::Cloth],
+            Lumber => &[Good::Lumber],
+            Paper => &[Good::Paper],
+            Steel => &[Good::Steel],
+            Fuel => &[Good::Fuel],
+            Clothing => &[Good::Clothing],
+            Furniture => &[Good::Furniture],
+            Hardware => &[Good::Hardware],
+            Armaments => &[Good::Armaments],
+            CannedFood => &[Good::CannedFood],
+            Horses => &[Good::Horses],
+        }
+    }
+
+    /// Lookup the commodity bucket for a specific good.
+    pub fn from_good(good: Good) -> Option<Self> {
+        use Good::*;
+        match good {
+            Grain => Some(TransportCommodity::Grain),
+            Fruit => Some(TransportCommodity::Fruit),
+            Cotton | Wool => Some(TransportCommodity::Fiber),
+            Livestock | Fish => Some(TransportCommodity::Meat),
+            Timber => Some(TransportCommodity::Timber),
+            Coal => Some(TransportCommodity::Coal),
+            Iron => Some(TransportCommodity::Iron),
+            Gold | Gems => Some(TransportCommodity::Precious),
+            Oil => Some(TransportCommodity::Oil),
+            Fabric | Cloth => Some(TransportCommodity::Fabric),
+            Lumber => Some(TransportCommodity::Lumber),
+            Paper => Some(TransportCommodity::Paper),
+            Steel => Some(TransportCommodity::Steel),
+            Fuel => Some(TransportCommodity::Fuel),
+            Clothing => Some(TransportCommodity::Clothing),
+            Furniture => Some(TransportCommodity::Furniture),
+            Hardware => Some(TransportCommodity::Hardware),
+            Armaments => Some(TransportCommodity::Armaments),
+            CannedFood => Some(TransportCommodity::CannedFood),
+            Horses => Some(TransportCommodity::Horses),
+        }
+    }
+
+    /// Raw resource tiles that map to this commodity bucket.
+    pub fn resource_types(self) -> &'static [ResourceType] {
+        use TransportCommodity::*;
+        match self {
+            Grain => &[ResourceType::Grain],
+            Fruit => &[ResourceType::Fruit],
+            Fiber => &[ResourceType::Cotton, ResourceType::Wool],
+            Meat => &[ResourceType::Livestock],
+            Timber => &[ResourceType::Timber],
+            Coal => &[ResourceType::Coal],
+            Iron => &[ResourceType::Iron],
+            Precious => &[ResourceType::Gold, ResourceType::Gems],
+            Oil => &[ResourceType::Oil],
+            // Manufactured goods do not map to tile resources directly.
+            Fabric | Lumber | Paper | Steel | Fuel | Clothing | Furniture | Hardware
+            | Armaments | CannedFood | Horses => &[],
+        }
+    }
+
+    /// Ordering used for UI layout: resources → materials → goods.
+    pub const ORDERED: [TransportCommodity; 20] = [
+        TransportCommodity::Grain,
+        TransportCommodity::Fruit,
+        TransportCommodity::Fiber,
+        TransportCommodity::Meat,
+        TransportCommodity::Timber,
+        TransportCommodity::Coal,
+        TransportCommodity::Iron,
+        TransportCommodity::Precious,
+        TransportCommodity::Oil,
+        TransportCommodity::Fabric,
+        TransportCommodity::Lumber,
+        TransportCommodity::Paper,
+        TransportCommodity::Steel,
+        TransportCommodity::Fuel,
+        TransportCommodity::Clothing,
+        TransportCommodity::Furniture,
+        TransportCommodity::Hardware,
+        TransportCommodity::Armaments,
+        TransportCommodity::CannedFood,
+        TransportCommodity::Horses,
+    ];
+}
+
+/// Total capacity available to each nation.
+#[derive(Default, Resource, Debug, Clone)]
+pub struct TransportCapacity {
+    pub nations: HashMap<Entity, CapacitySnapshot>,
+}
+
+#[derive(Default, Debug, Clone, Copy)]
+pub struct CapacitySnapshot {
+    pub total: u32,
+    pub used: u32,
+}
+
+/// Desired allocations per nation and commodity.
+#[derive(Default, Resource, Debug, Clone)]
+pub struct TransportAllocations {
+    pub nations: HashMap<Entity, NationAllocations>,
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct NationAllocations {
+    pub commodities: HashMap<TransportCommodity, AllocationSlot>,
+}
+
+#[derive(Default, Debug, Clone, Copy)]
+pub struct AllocationSlot {
+    pub requested: u32,
+    pub granted: u32,
+}
+
+/// Snapshot of supply/demand used for UI hints.
+#[derive(Default, Resource, Debug, Clone)]
+pub struct TransportDemandSnapshot {
+    pub nations: HashMap<Entity, HashMap<TransportCommodity, DemandEntry>>,
+}
+
+#[derive(Default, Debug, Clone, Copy)]
+pub struct DemandEntry {
+    pub supply: u32,
+    pub demand: u32,
+}
+
+impl NationAllocations {
+    pub fn slot_mut(&mut self, commodity: TransportCommodity) -> &mut AllocationSlot {
+        self.commodities.entry(commodity).or_default()
+    }
+
+    pub fn slot(&self, commodity: TransportCommodity) -> AllocationSlot {
+        self.commodities
+            .get(&commodity)
+            .copied()
+            .unwrap_or_default()
+    }
+}
+
+impl TransportAllocations {
+    pub fn ensure_nation(&mut self, nation: Entity) -> &mut NationAllocations {
+        self.nations.entry(nation).or_default()
+    }
+
+    pub fn slot(&self, nation: Entity, commodity: TransportCommodity) -> AllocationSlot {
+        self.nations
+            .get(&nation)
+            .map(|alloc| alloc.slot(commodity))
+            .unwrap_or_default()
+    }
+}
+
+impl TransportCapacity {
+    pub fn snapshot_mut(&mut self, nation: Entity) -> &mut CapacitySnapshot {
+        self.nations.entry(nation).or_default()
+    }
+
+    pub fn snapshot(&self, nation: Entity) -> CapacitySnapshot {
+        self.nations.get(&nation).copied().unwrap_or_default()
+    }
+}

--- a/src/economy/transport/tests.rs
+++ b/src/economy/transport/tests.rs
@@ -1,0 +1,144 @@
+use bevy::prelude::*;
+use bevy_ecs_tilemap::prelude::TilePos;
+use std::collections::HashMap;
+
+use crate::economy::allocation::Allocations;
+use crate::economy::production::{Buildings, ConnectedProduction};
+use crate::economy::transport::{
+    apply_transport_allocations, update_transport_capacity, update_transport_demand_snapshot,
+    TransportAllocations, TransportCapacity, TransportCommodity, TransportDemandSnapshot,
+};
+use crate::economy::workforce::Workforce;
+use crate::resources::ResourceType;
+use super::types::{Depot, Port};
+
+#[test]
+fn capacity_totals_respect_connected_improvements() {
+    let mut app = App::new();
+    app.init_resource::<TransportCapacity>();
+
+    let nation = app.world_mut().spawn_empty().id();
+
+    app.world_mut().spawn(Depot {
+        position: TilePos { x: 0, y: 0 },
+        owner: nation,
+        connected: true,
+    });
+
+    app.world_mut().spawn(Depot {
+        position: TilePos { x: 1, y: 1 },
+        owner: nation,
+        connected: false,
+    });
+
+    app.world_mut().spawn(Port {
+        position: TilePos { x: 2, y: 2 },
+        owner: nation,
+        connected: true,
+        is_river: false,
+    });
+
+    app.add_systems(Update, update_transport_capacity);
+    app.update();
+
+    let capacity = app.world().resource::<TransportCapacity>();
+    let snapshot = capacity.snapshot(nation);
+    // Depot contributes 6, port contributes 8 => 14 total
+    assert_eq!(snapshot.total, 14);
+    assert_eq!(snapshot.used, 0);
+}
+
+#[test]
+fn allocation_granted_values_clamp_to_total_capacity() {
+    let mut app = App::new();
+    app.init_resource::<TransportCapacity>();
+    app.init_resource::<TransportAllocations>();
+    app.add_systems(Update, apply_transport_allocations);
+
+    let nation = app.world_mut().spawn_empty().id();
+
+    {
+        let mut capacity = app.world_mut().resource_mut::<TransportCapacity>();
+        let snapshot = capacity.snapshot_mut(nation);
+        snapshot.total = 5;
+        snapshot.used = 0;
+    }
+
+    {
+        let mut allocations = app
+            .world_mut()
+            .resource_mut::<TransportAllocations>();
+        let nation_alloc = allocations.ensure_nation(nation);
+        nation_alloc
+            .slot_mut(TransportCommodity::Grain)
+            .requested = 4;
+        nation_alloc
+            .slot_mut(TransportCommodity::Coal)
+            .requested = 4;
+    }
+
+    app.update();
+
+    let allocations = app.world().resource::<TransportAllocations>();
+    let grain_slot = allocations.slot(nation, TransportCommodity::Grain);
+    let coal_slot = allocations.slot(nation, TransportCommodity::Coal);
+    assert_eq!(grain_slot.granted, 4);
+    assert_eq!(coal_slot.granted, 1);
+
+    let capacity = app.world().resource::<TransportCapacity>();
+    let snapshot = capacity.snapshot(nation);
+    assert_eq!(snapshot.used, 5);
+}
+
+#[test]
+fn demand_snapshot_collects_supply_and_worker_demand() {
+    let mut app = App::new();
+    app.init_resource::<TransportDemandSnapshot>();
+
+    let nation = app
+        .world_mut()
+        .spawn((Allocations::default(), Buildings::with_all_initial(), Workforce::new()))
+        .id();
+
+    {
+        let mut workforce = app.world_mut().get_mut::<Workforce>(nation).unwrap();
+        workforce.add_untrained(3);
+    }
+
+    let mut connected = ConnectedProduction::default();
+    let mut resource_map = HashMap::new();
+    resource_map.insert(ResourceType::Grain, (1, 6));
+    resource_map.insert(ResourceType::Coal, (1, 3));
+    connected.0.insert(nation, resource_map);
+    app.insert_resource(connected);
+
+    app.add_systems(Update, update_transport_demand_snapshot);
+    app.update();
+
+    let snapshot = app.world().resource::<TransportDemandSnapshot>();
+    let nation_entries = snapshot
+        .nations
+        .get(&nation)
+        .expect("demand entry for nation");
+
+    let grain = nation_entries
+        .get(&TransportCommodity::Grain)
+        .expect("grain entry");
+    assert_eq!(grain.supply, 6);
+    assert_eq!(grain.demand, 1);
+
+    let fruit = nation_entries
+        .get(&TransportCommodity::Fruit)
+        .expect("fruit entry");
+    assert_eq!(fruit.demand, 1);
+
+    let meat = nation_entries
+        .get(&TransportCommodity::Meat)
+        .expect("meat entry");
+    assert_eq!(meat.demand, 1);
+
+    let coal = nation_entries
+        .get(&TransportCommodity::Coal)
+        .expect("coal entry");
+    assert_eq!(coal.supply, 3);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,11 @@ use crate::economy::allocation_systems;
 use crate::economy::production::{
     ConnectedProduction, calculate_connected_production, run_production,
 };
-use crate::economy::transport::{self, compute_rail_connectivity};
+use crate::economy::transport::{
+    self, TransportAdjustAllocation, TransportAllocations, TransportCapacity,
+    TransportDemandSnapshot, apply_transport_allocations, compute_rail_connectivity,
+    update_transport_capacity, update_transport_demand_snapshot,
+};
 use crate::economy::workforce;
 use crate::economy::{Calendar, Capital, NationId, PlaceImprovement, PlayerNation, Rails, Roads};
 use crate::helpers::camera;
@@ -60,6 +64,9 @@ pub mod tiles;
 pub mod transport_rendering;
 pub mod turn_system;
 pub mod ui;
+
+#[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone, Copy)]
+struct InGameEconomySet;
 
 /// Marker resource to track if tilemap has been created
 #[derive(Resource)]
@@ -238,12 +245,17 @@ pub fn app() -> App {
     .add_sub_state::<GameMode>()
     .add_systems(Update, log_transitions::<AppState>)
     .add_systems(Update, log_transitions::<GameMode>)
+    .configure_sets(Update, InGameEconomySet.run_if(in_state(AppState::InGame)))
     // Root app state: start in Main Menu; also set up in-game mode state (Map)
     .insert_resource(Calendar::default())
     .insert_resource(Roads::default())
     .insert_resource(Rails::default())
     .insert_resource(ConnectedProduction::default())
+    .insert_resource(TransportCapacity::default())
+    .insert_resource(TransportAllocations::default())
+    .insert_resource(TransportDemandSnapshot::default())
     .add_message::<PlaceImprovement>()
+    .add_message::<TransportAdjustAllocation>()
     .add_systems(Startup, (setup_camera,))
     // Start loading terrain atlas at startup
     .add_systems(Startup, terrain_atlas::start_terrain_atlas_loading)
@@ -268,53 +280,57 @@ pub fn app() -> App {
         (
             transport::apply_improvements,
             compute_rail_connectivity.after(transport::apply_improvements),
-            calculate_connected_production.after(compute_rail_connectivity),
+            update_transport_capacity.after(compute_rail_connectivity),
+            calculate_connected_production.after(update_transport_capacity),
+            update_transport_demand_snapshot.after(calculate_connected_production),
+            apply_transport_allocations,
             run_production,
-            // Execute recruitment and training orders during Processing phase
+        )
+            .in_set(InGameEconomySet),
+    )
+    .add_systems(
+        Update,
+        (
             workforce::execute_recruitment_orders,
             workforce::execute_training_orders,
-            // Advance rail construction at the start of each player turn
-            transport::advance_rail_construction
-                .run_if(resource_changed::<TurnSystem>)
-                .run_if(|turn_system: Res<TurnSystem>| turn_system.phase == TurnPhase::PlayerTurn),
-            // Reset civilian actions at the start of each player turn
-            reset_civilian_actions
-                .run_if(resource_changed::<TurnSystem>)
-                .run_if(|turn_system: Res<TurnSystem>| turn_system.phase == TurnPhase::PlayerTurn),
-            // Complete improvement jobs before advancing (so we can log completion)
-            complete_improvement_jobs
-                .run_if(resource_changed::<TurnSystem>)
-                .run_if(|turn_system: Res<TurnSystem>| turn_system.phase == TurnPhase::PlayerTurn),
-            // Advance civilian jobs at the start of each player turn
-            advance_civilian_jobs
-                .run_if(resource_changed::<TurnSystem>)
-                .run_if(|turn_system: Res<TurnSystem>| turn_system.phase == TurnPhase::PlayerTurn),
-            // Feed workers at the start of each player turn
-            workforce::feed_workers
-                .run_if(resource_changed::<TurnSystem>)
-                .run_if(|turn_system: Res<TurnSystem>| turn_system.phase == TurnPhase::PlayerTurn),
-            // Worker recruitment and training (run anytime during player turn)
             workforce::handle_recruitment,
             workforce::handle_training,
-            // Allocation adjustment systems (run during PlayerTurn)
             allocation_systems::apply_recruitment_adjustments,
             allocation_systems::apply_training_adjustments,
             allocation_systems::apply_production_adjustments,
             allocation_systems::apply_market_order_adjustments,
-            // Finalize allocations at turn end (before Processing)
+        )
+            .in_set(InGameEconomySet),
+    )
+    .add_systems(
+        Update,
+        (
+            transport::advance_rail_construction
+                .run_if(resource_changed::<TurnSystem>)
+                .run_if(|turn_system: Res<TurnSystem>| turn_system.phase == TurnPhase::PlayerTurn),
+            reset_civilian_actions
+                .run_if(resource_changed::<TurnSystem>)
+                .run_if(|turn_system: Res<TurnSystem>| turn_system.phase == TurnPhase::PlayerTurn),
+            complete_improvement_jobs
+                .run_if(resource_changed::<TurnSystem>)
+                .run_if(|turn_system: Res<TurnSystem>| turn_system.phase == TurnPhase::PlayerTurn),
+            advance_civilian_jobs
+                .run_if(resource_changed::<TurnSystem>)
+                .run_if(|turn_system: Res<TurnSystem>| turn_system.phase == TurnPhase::PlayerTurn),
+            workforce::feed_workers
+                .run_if(resource_changed::<TurnSystem>)
+                .run_if(|turn_system: Res<TurnSystem>| turn_system.phase == TurnPhase::PlayerTurn),
             allocation_systems::finalize_allocations
                 .run_if(resource_changed::<TurnSystem>)
                 .run_if(|turn_system: Res<TurnSystem>| turn_system.phase == TurnPhase::Processing),
-            // Reset allocations at start of PlayerTurn
             allocation_systems::reset_allocations
                 .run_if(resource_changed::<TurnSystem>)
                 .run_if(|turn_system: Res<TurnSystem>| turn_system.phase == TurnPhase::PlayerTurn),
-            // Update labor pools at start of PlayerTurn (sync with worker counts)
             workforce::update_labor_pools
                 .run_if(resource_changed::<TurnSystem>)
                 .run_if(|turn_system: Res<TurnSystem>| turn_system.phase == TurnPhase::PlayerTurn),
         )
-            .run_if(in_state(AppState::InGame)),
+            .in_set(InGameEconomySet),
     )
     .add_systems(
         Update,

--- a/src/save.rs
+++ b/src/save.rs
@@ -79,11 +79,7 @@ impl Plugin for GameSavePlugin {
             .add_observer(rebuild_runtime_state_after_load)
             .add_systems(
                 Update,
-                (
-                    process_save_requests,
-                    process_load_requests,
-                )
-                    .run_if(in_state(AppState::InGame)),
+                (process_save_requests, process_load_requests).run_if(in_state(AppState::InGame)),
             );
     }
 }
@@ -204,22 +200,24 @@ mod tests {
     use bevy::app::App;
     use bevy::ecs::message::{MessageReader, MessageWriter};
     use bevy::ecs::system::RunSystemOnce;
-    use bevy::prelude::{AppExtStates, Commands, Component, MinimalPlugins, Reflect, ReflectComponent};
+    use bevy::prelude::{
+        AppExtStates, Commands, Component, MinimalPlugins, Reflect, ReflectComponent,
+    };
     use bevy::state::app::StatesPlugin;
 
     use moonshine_save::prelude::Save;
 
+    use crate::economy::Calendar;
     use crate::economy::allocation::Allocations;
+    use crate::economy::nation::{NationId, PlayerNation};
     use crate::economy::reservation::ReservationSystem;
     use crate::economy::transport::{Rails, Roads};
-    use crate::economy::Calendar;
-    use crate::economy::nation::{NationId, PlayerNation};
     use crate::province_setup::ProvincesGenerated;
     use crate::save::{
         GameSavePlugin, LoadGameCompleted, LoadGameRequest, SaveGameCompleted, SaveGameRequest,
     };
-    use crate::ui::menu::AppState;
     use crate::turn_system::TurnSystem;
+    use crate::ui::menu::AppState;
 
     #[derive(Component, Reflect, Default, Clone)]
     #[reflect(Component)]
@@ -229,7 +227,10 @@ mod tests {
 
     fn temp_save_path(label: &str) -> PathBuf {
         let mut path = std::env::temp_dir();
-        path.push(format!("rust_imperialism_{label}_{}.ron", rand::random::<u64>()));
+        path.push(format!(
+            "rust_imperialism_{label}_{}.ron",
+            rand::random::<u64>()
+        ));
         path
     }
 
@@ -313,11 +314,13 @@ mod tests {
 
         let mut app = init_test_app();
         let load_request_path = path.clone();
-        let _ = app.world_mut().run_system_once(move |mut writer: MessageWriter<LoadGameRequest>| {
-            writer.write(LoadGameRequest {
-                path: Some(load_request_path.clone()),
-            });
-        });
+        let _ =
+            app.world_mut()
+                .run_system_once(move |mut writer: MessageWriter<LoadGameRequest>| {
+                    writer.write(LoadGameRequest {
+                        path: Some(load_request_path.clone()),
+                    });
+                });
 
         app.update();
         app.update();

--- a/src/ui/transport.rs
+++ b/src/ui/transport.rs
@@ -1,12 +1,16 @@
+use bevy::ecs::hierarchy::ChildSpawnerCommands;
 use bevy::prelude::*;
+use bevy::ui::RelativeCursorPosition;
 use bevy_ecs_tilemap::prelude::TilePos;
 
 use super::button_style::*;
 use super::generic_systems::despawn_screen;
 use crate::economy::nation::PlayerNation;
-use crate::economy::production::ConnectedProduction;
+use crate::economy::transport::{
+    TransportAdjustAllocation, TransportAllocations, TransportCapacity, TransportCommodity,
+    TransportDemandSnapshot, transport_capacity, transport_demand, transport_slot,
+};
 use crate::economy::{ImprovementKind, PlaceImprovement};
-use crate::resources::ALL_RESOURCES;
 use crate::ui::logging::TerminalLogEvent;
 use crate::ui::mode::{GameMode, MapModeButton};
 
@@ -23,6 +27,71 @@ pub struct TransportSelectTile {
     pub pos: TilePos,
 }
 
+#[derive(Component)]
+struct TransportLabel {
+    commodity: TransportCommodity,
+}
+
+#[derive(Component)]
+struct TransportSlider {
+    commodity: TransportCommodity,
+    nation: Entity,
+}
+
+#[derive(Component)]
+struct TransportSliderFill {
+    commodity: TransportCommodity,
+    kind: SliderFillKind,
+}
+
+#[derive(Component)]
+struct TransportSliderBackground {
+    commodity: TransportCommodity,
+}
+
+#[derive(Component)]
+struct TransportStatsText {
+    commodity: TransportCommodity,
+}
+
+#[derive(Component)]
+struct TransportCapacityText;
+
+#[derive(Component)]
+struct TransportCapacityFill;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SliderFillKind {
+    Requested,
+    Granted,
+}
+
+const RESOURCE_COMMODITIES: &[TransportCommodity] = &[
+    TransportCommodity::Grain,
+    TransportCommodity::Fruit,
+    TransportCommodity::Fiber,
+    TransportCommodity::Meat,
+    TransportCommodity::Timber,
+    TransportCommodity::Coal,
+    TransportCommodity::Iron,
+    TransportCommodity::Precious,
+    TransportCommodity::Oil,
+];
+
+const INDUSTRY_COMMODITIES: &[TransportCommodity] = &[
+    TransportCommodity::Fabric,
+    TransportCommodity::Lumber,
+    TransportCommodity::Paper,
+    TransportCommodity::Steel,
+    TransportCommodity::Fuel,
+    TransportCommodity::Clothing,
+    TransportCommodity::Furniture,
+    TransportCommodity::Hardware,
+    TransportCommodity::Armaments,
+    TransportCommodity::CannedFood,
+    TransportCommodity::Horses,
+];
+
 pub struct TransportUIPlugin;
 
 impl Plugin for TransportUIPlugin {
@@ -36,7 +105,12 @@ impl Plugin for TransportUIPlugin {
             )
             .add_systems(
                 Update,
-                handle_transport_selection.run_if(in_state(GameMode::Transport)),
+                (
+                    handle_transport_selection,
+                    handle_transport_slider_input,
+                    update_transport_ui_elements,
+                )
+                    .run_if(in_state(GameMode::Transport)),
             );
     }
 }
@@ -66,12 +140,35 @@ pub fn handle_transport_selection(
 }
 
 /// Create the transport screen UI when entering the transport game mode
-fn setup_transport_screen(
-    mut commands: Commands,
-    production: Res<ConnectedProduction>,
-    player: Option<Res<PlayerNation>>,
-) {
-    let player_production = player.and_then(|p| production.0.get(&p.0));
+fn setup_transport_screen(mut commands: Commands, player: Option<Res<PlayerNation>>) {
+    let Some(player) = player else {
+        commands
+            .spawn((
+                Node {
+                    position_type: PositionType::Absolute,
+                    width: Val::Percent(100.0),
+                    height: Val::Percent(100.0),
+                    justify_content: JustifyContent::Center,
+                    align_items: AlignItems::Center,
+                    ..default()
+                },
+                BackgroundColor(Color::srgba(0.05, 0.06, 0.08, 0.92)),
+                TransportScreen,
+            ))
+            .with_children(|parent| {
+                parent.spawn((
+                    Text::new("Transport data unavailable: no active player nation"),
+                    TextFont {
+                        font_size: 18.0,
+                        ..default()
+                    },
+                    TextColor(Color::srgb(0.8, 0.6, 0.6)),
+                ));
+            });
+        return;
+    };
+
+    let nation = player.entity();
 
     commands
         .spawn((
@@ -79,9 +176,9 @@ fn setup_transport_screen(
                 position_type: PositionType::Absolute,
                 width: Val::Percent(100.0),
                 height: Val::Percent(100.0),
-                padding: UiRect::all(Val::Px(16.0)),
+                padding: UiRect::all(Val::Px(24.0)),
                 flex_direction: FlexDirection::Column,
-                row_gap: Val::Px(12.0),
+                row_gap: Val::Px(20.0),
                 ..default()
             },
             BackgroundColor(Color::srgba(0.05, 0.06, 0.08, 0.92)),
@@ -89,54 +186,82 @@ fn setup_transport_screen(
         ))
         .with_children(|parent| {
             parent.spawn((
-                Text::new("Transport Mode: Connected Production"),
+                Text::new("Transport Allocation"),
                 TextFont {
-                    font_size: 20.0,
+                    font_size: 26.0,
                     ..default()
                 },
-                TextColor(Color::srgb(0.9, 0.95, 1.0)),
+                TextColor(Color::srgb(0.92, 0.95, 1.0)),
             ));
 
             parent
                 .spawn(Node {
-                    flex_direction: FlexDirection::Column,
-                    row_gap: Val::Px(4.0),
-                    margin: UiRect {
-                        top: Val::Px(20.0),
-                        ..default()
-                    },
+                    flex_direction: FlexDirection::Row,
+                    column_gap: Val::Px(32.0),
+                    flex_grow: 1.0,
                     ..default()
                 })
-                .with_children(|list| {
-                    for &res_type in ALL_RESOURCES {
-                        let (count, total) = player_production
-                            .and_then(|p| p.get(&res_type))
-                            .copied()
-                            .unwrap_or((0, 0));
+                .with_children(|columns: &mut ChildSpawnerCommands| {
+                    spawn_commodity_column(columns, "Resources", RESOURCE_COMMODITIES, nation);
+                    spawn_commodity_column(
+                        columns,
+                        "Materials & Goods",
+                        INDUSTRY_COMMODITIES,
+                        nation,
+                    );
+                });
 
-                        let text_content = format!(
-                            "{:?}: {} improvements (producing {} units)",
-                            res_type, count, total
-                        );
+            parent
+                .spawn(Node {
+                    flex_direction: FlexDirection::Column,
+                    row_gap: Val::Px(8.0),
+                    ..default()
+                })
+                .with_children(|capacity| {
+                    capacity.spawn((
+                        Text::new("Capacity: 0 / 0 used"),
+                        TextFont {
+                            font_size: 16.0,
+                            ..default()
+                        },
+                        TextColor(Color::srgb(0.8, 0.84, 0.92)),
+                        TransportCapacityText,
+                    ));
 
-                        list.spawn((
-                            Text::new(text_content),
-                            TextFont {
-                                font_size: 14.0,
+                    capacity
+                        .spawn((
+                            Node {
+                                width: Val::Percent(60.0),
+                                max_width: Val::Px(420.0),
+                                height: Val::Px(18.0),
+                                border: UiRect::all(Val::Px(1.0)),
                                 ..default()
                             },
-                            TextColor(Color::srgb(0.8, 0.8, 0.9)),
-                        ));
-                    }
+                            BackgroundColor(Color::srgba(0.12, 0.14, 0.18, 1.0)),
+                        ))
+                        .with_children(|bar| {
+                            bar.spawn((
+                                Node {
+                                    position_type: PositionType::Absolute,
+                                    left: Val::Px(0.0),
+                                    top: Val::Px(0.0),
+                                    height: Val::Percent(100.0),
+                                    width: Val::Percent(0.0),
+                                    ..default()
+                                },
+                                BackgroundColor(Color::srgb(0.35, 0.55, 0.88)),
+                                TransportCapacityFill,
+                            ));
+                        });
                 });
 
             parent.spawn((
                 Button,
                 Node {
                     position_type: PositionType::Absolute,
-                    top: Val::Px(16.0),
-                    right: Val::Px(16.0),
-                    padding: UiRect::all(Val::Px(6.0)),
+                    top: Val::Px(24.0),
+                    right: Val::Px(24.0),
+                    padding: UiRect::axes(Val::Px(12.0), Val::Px(8.0)),
                     ..default()
                 },
                 BackgroundColor(NORMAL_BUTTON),
@@ -153,5 +278,246 @@ fn setup_transport_screen(
         });
 }
 
-// Note: despawn_transport_screen replaced with generic despawn_screen::<TransportScreen>
-// See src/ui/generic_systems.rs for the generic implementation
+fn spawn_commodity_column(
+    parent: &mut ChildSpawnerCommands,
+    title: &str,
+    commodities: &[TransportCommodity],
+    nation: Entity,
+) {
+    parent
+        .spawn(Node {
+            flex_direction: FlexDirection::Column,
+            row_gap: Val::Px(12.0),
+            flex_grow: 1.0,
+            ..default()
+        })
+        .with_children(|column: &mut ChildSpawnerCommands| {
+            column.spawn((
+                Text::new(title),
+                TextFont {
+                    font_size: 20.0,
+                    ..default()
+                },
+                TextColor(Color::srgb(0.85, 0.9, 1.0)),
+            ));
+
+            for &commodity in commodities {
+                spawn_commodity_row(column, commodity, nation);
+            }
+        });
+}
+
+fn spawn_commodity_row(
+    parent: &mut ChildSpawnerCommands,
+    commodity: TransportCommodity,
+    nation: Entity,
+) {
+    parent
+        .spawn((Node {
+            flex_direction: FlexDirection::Row,
+            align_items: AlignItems::Center,
+            column_gap: Val::Px(16.0),
+            ..default()
+        },))
+        .with_children(|row: &mut ChildSpawnerCommands| {
+            row.spawn((
+                Text::new(format!("{:?}", commodity)),
+                TextFont {
+                    font_size: 16.0,
+                    ..default()
+                },
+                TextColor(Color::srgb(0.82, 0.86, 0.95)),
+                TransportLabel { commodity },
+            ));
+
+            row.spawn((
+                Button,
+                Node {
+                    width: Val::Px(220.0),
+                    height: Val::Px(20.0),
+                    border: UiRect::all(Val::Px(1.0)),
+                    justify_content: JustifyContent::FlexStart,
+                    align_items: AlignItems::Center,
+                    position_type: PositionType::Relative,
+                    ..default()
+                },
+                BackgroundColor(Color::srgba(0.12, 0.14, 0.18, 1.0)),
+                RelativeCursorPosition::default(),
+                TransportSlider { commodity, nation },
+                TransportSliderBackground { commodity },
+            ))
+            .with_children(|slider: &mut ChildSpawnerCommands| {
+                slider.spawn((
+                    Node {
+                        position_type: PositionType::Absolute,
+                        left: Val::Px(0.0),
+                        top: Val::Px(0.0),
+                        height: Val::Percent(100.0),
+                        width: Val::Percent(0.0),
+                        ..default()
+                    },
+                    BackgroundColor(Color::srgb(0.32, 0.45, 0.72)),
+                    TransportSliderFill {
+                        commodity,
+                        kind: SliderFillKind::Requested,
+                    },
+                ));
+
+                slider.spawn((
+                    Node {
+                        position_type: PositionType::Absolute,
+                        left: Val::Px(0.0),
+                        top: Val::Px(0.0),
+                        height: Val::Percent(100.0),
+                        width: Val::Percent(0.0),
+                        ..default()
+                    },
+                    BackgroundColor(Color::srgb(0.28, 0.76, 0.52)),
+                    TransportSliderFill {
+                        commodity,
+                        kind: SliderFillKind::Granted,
+                    },
+                ));
+            });
+
+            row.spawn((
+                Text::new("Requested 0 / 0 | Supply 0 | Demand 0"),
+                TextFont {
+                    font_size: 14.0,
+                    ..default()
+                },
+                TextColor(Color::srgb(0.75, 0.78, 0.85)),
+                TransportStatsText { commodity },
+            ));
+        });
+}
+
+fn handle_transport_slider_input(
+    player: Option<Res<PlayerNation>>,
+    capacity: Res<TransportCapacity>,
+    mut interactions: Query<
+        (&Interaction, &RelativeCursorPosition, &TransportSlider),
+        (Changed<Interaction>, With<Button>),
+    >,
+    mut adjust_writer: MessageWriter<TransportAdjustAllocation>,
+) {
+    let Some(player) = player else {
+        return;
+    };
+
+    let nation = player.entity();
+    let snapshot = transport_capacity(&capacity, nation);
+    if snapshot.total == 0 {
+        return;
+    }
+
+    for (interaction, cursor, slider) in interactions.iter_mut() {
+        if *interaction != Interaction::Pressed {
+            continue;
+        }
+
+        if slider.nation != nation {
+            continue;
+        }
+
+        let Some(position) = cursor.normalized else {
+            continue;
+        };
+
+        let ratio = position.x.clamp(0.0, 1.0);
+        let requested = (ratio * snapshot.total as f32).round() as u32;
+        adjust_writer.write(TransportAdjustAllocation {
+            nation,
+            commodity: slider.commodity,
+            requested,
+        });
+    }
+}
+
+fn update_transport_ui_elements(
+    player: Option<Res<PlayerNation>>,
+    capacity: Res<TransportCapacity>,
+    allocations: Res<TransportAllocations>,
+    demand_snapshot: Res<TransportDemandSnapshot>,
+    mut slider_fills: Query<(&mut Node, &TransportSliderFill)>,
+    mut slider_backgrounds: Query<(&mut BackgroundColor, &TransportSliderBackground)>,
+    mut stat_texts: Query<(&mut Text, &mut TextColor, &TransportStatsText)>,
+    mut labels: Query<(&mut TextColor, &TransportLabel)>,
+    mut capacity_text: Query<&mut Text, With<TransportCapacityText>>,
+    mut capacity_fill: Query<&mut Node, With<TransportCapacityFill>>,
+) {
+    if !capacity.is_changed() && !allocations.is_changed() && !demand_snapshot.is_changed() {
+        return;
+    }
+
+    let Some(player) = player else {
+        return;
+    };
+    let nation = player.entity();
+    let snapshot = transport_capacity(&capacity, nation);
+
+    for (mut node, fill) in slider_fills.iter_mut() {
+        let slot = transport_slot(&allocations, nation, fill.commodity);
+        let demand = transport_demand(&demand_snapshot, nation, fill.commodity);
+        let scale = snapshot
+            .total
+            .max(slot.requested)
+            .max(slot.granted)
+            .max(demand.demand)
+            .max(1);
+        let value = match fill.kind {
+            SliderFillKind::Requested => slot.requested,
+            SliderFillKind::Granted => slot.granted,
+        };
+        let percent = (value as f32 / scale as f32 * 100.0).clamp(0.0, 100.0);
+        node.width = Val::Percent(percent);
+    }
+
+    for (mut background, slider) in slider_backgrounds.iter_mut() {
+        let demand = transport_demand(&demand_snapshot, nation, slider.commodity);
+        if demand.supply == 0 {
+            background.0 = Color::srgba(0.08, 0.08, 0.1, 0.7);
+        } else {
+            background.0 = Color::srgba(0.12, 0.14, 0.18, 1.0);
+        }
+    }
+
+    for (mut text, mut color, stats) in stat_texts.iter_mut() {
+        let slot = transport_slot(&allocations, nation, stats.commodity);
+        let demand = transport_demand(&demand_snapshot, nation, stats.commodity);
+        text.0 = format!(
+            "Requested {} / {} | Supply {} | Demand {}",
+            slot.requested, slot.granted, demand.supply, demand.demand
+        );
+
+        if demand.demand == 0 {
+            color.0 = Color::srgb(0.75, 0.78, 0.85);
+        } else if slot.granted >= demand.demand {
+            color.0 = Color::srgb(0.55, 0.85, 0.6);
+        } else {
+            color.0 = Color::srgb(0.85, 0.45, 0.45);
+        }
+    }
+
+    for (mut color, label) in labels.iter_mut() {
+        let demand = transport_demand(&demand_snapshot, nation, label.commodity);
+        if demand.supply == 0 {
+            color.0 = Color::srgb(0.5, 0.52, 0.58);
+        } else {
+            color.0 = Color::srgb(0.82, 0.86, 0.95);
+        }
+    }
+
+    if let Ok(mut text) = capacity_text.single_mut() {
+        text.0 = format!("Capacity: {} / {} used", snapshot.used, snapshot.total);
+    }
+
+    if let Ok(mut node) = capacity_fill.single_mut() {
+        let percent = if snapshot.total == 0 {
+            0.0
+        } else {
+            (snapshot.used as f32 / snapshot.total as f32 * 100.0).clamp(0.0, 100.0)
+        };
+        node.width = Val::Percent(percent);
+    }
+}


### PR DESCRIPTION
## Summary
- implement transport commodity resources to track capacity, allocations, and demand snapshots for each nation
- add systems that derive capacity from connected depots/ports, process slider adjustment messages, and expose demand helpers to the UI
- rebuild the transport mode screen with slider widgets, capacity feedback, and color-coded supply/demand text

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68f2d6dafa58832fb3315d6eeec113c9