### PR TITLE
Expand diplomacy war obligations and alliance requests

### DIFF
--- a/src/diplomacy/tests.rs
+++ b/src/diplomacy/tests.rs
@@ -214,6 +214,61 @@ fn embassy_requires_consulate_and_relations() {
 }
 
 #[test]
+fn declare_war_shifts_world_opinion() {
+    let mut world = setup_world();
+
+    world.spawn((NationId(1), Name("Empire".into()), Treasury::new(1_000)));
+    world.spawn((NationId(2), Name("Rival".into()), Treasury::new(1_000)));
+    world.spawn((NationId(3), Name("Friend".into()), Treasury::new(1_000)));
+    world.spawn((NationId(4), Name("Foe".into()), Treasury::new(1_000)));
+
+    world.resource_mut::<TurnSystem>().phase = TurnPhase::Processing;
+    let _ = world.run_system_once(sync_diplomatic_pairs);
+
+    // Friend admires the rival, foe despises them
+    {
+        let mut state = world.resource_mut::<DiplomacyState>();
+        state.adjust_score(NationId(3), NationId(2), 60);
+        state.adjust_score(NationId(4), NationId(2), -70);
+    }
+
+    {
+        let mut messages = world.resource_mut::<Messages<DiplomaticOrder>>();
+        messages.write(DiplomaticOrder {
+            actor: NationId(1),
+            target: NationId(2),
+            kind: DiplomaticOrderKind::DeclareWar,
+        });
+    }
+
+    let _ = world.run_system_once(process_diplomatic_orders);
+
+    let state = world.resource::<DiplomacyState>();
+    let relation_with_friend = state
+        .relation(NationId(1), NationId(3))
+        .expect("friend relation")
+        .score;
+    let relation_with_foe = state
+        .relation(NationId(1), NationId(4))
+        .expect("foe relation")
+        .score;
+    let war_state = state
+        .relation(NationId(1), NationId(2))
+        .expect("war relation")
+        .treaty
+        .at_war;
+
+    assert!(war_state, "war flag should be set against rival");
+    assert!(
+        relation_with_friend < 0,
+        "friend of rival should dislike us"
+    );
+    assert!(relation_with_foe > 0, "enemy of rival should appreciate us");
+    assert!(relation_with_friend <= -6);
+    assert!(relation_with_foe >= 6);
+}
+
+#[test]
 fn offer_peace_creates_pending_offer() {
     let mut world = setup_world();
 
@@ -246,6 +301,37 @@ fn offer_peace_creates_pending_offer() {
         .unwrap();
     assert!(relation.treaty.at_war);
     assert_eq!(world.resource::<DiplomaticOffers>().len(), 1);
+}
+
+#[test]
+fn proposing_non_aggression_creates_offer() {
+    let mut world = setup_world();
+
+    world.spawn((NationId(1), Name("Player".into()), Treasury::new(2_000)));
+    world.spawn((NationId(2), Name("Neighbor".into()), Treasury::new(1_000)));
+
+    world.resource_mut::<TurnSystem>().phase = TurnPhase::Processing;
+    let _ = world.run_system_once(sync_diplomatic_pairs);
+
+    world
+        .resource_mut::<DiplomacyState>()
+        .set_treaty(NationId(1), NationId(2), |t| t.embassy = true);
+
+    {
+        let mut messages = world.resource_mut::<Messages<DiplomaticOrder>>();
+        messages.write(DiplomaticOrder {
+            actor: NationId(1),
+            target: NationId(2),
+            kind: DiplomaticOrderKind::SignNonAggressionPact,
+        });
+    }
+
+    let _ = world.run_system_once(process_diplomatic_orders);
+
+    let offers = world.resource::<DiplomaticOffers>();
+    let mut pending = offers.iter_for(NationId(2));
+    let offer = pending.next().expect("pact offer present");
+    assert!(matches!(offer.kind, DiplomaticOfferKind::NonAggressionPact));
 }
 
 #[test]
@@ -287,6 +373,73 @@ fn accepting_peace_offer_sets_peace() {
         .unwrap();
     assert!(!relation.treaty.at_war);
     assert!(relation.score >= 10);
+}
+
+#[test]
+fn declare_war_triggers_alliance_calls() {
+    let mut world = setup_world();
+
+    world.spawn((NationId(1), Name("Attacker".into()), Treasury::new(1_000)));
+    world.spawn((NationId(2), Name("Victim".into()), Treasury::new(1_000)));
+    world.spawn((
+        NationId(3),
+        Name("Defender Ally".into()),
+        Treasury::new(1_000),
+    ));
+    world.spawn((
+        NationId(4),
+        Name("Aggressor Ally".into()),
+        Treasury::new(1_000),
+    ));
+
+    world.resource_mut::<TurnSystem>().phase = TurnPhase::Processing;
+    let _ = world.run_system_once(sync_diplomatic_pairs);
+
+    {
+        let mut state = world.resource_mut::<DiplomacyState>();
+        state.set_treaty(NationId(2), NationId(3), |t| {
+            t.alliance = true;
+            t.non_aggression_pact = true;
+            t.embassy = true;
+        });
+        state.set_treaty(NationId(1), NationId(4), |t| {
+            t.alliance = true;
+            t.non_aggression_pact = true;
+            t.embassy = true;
+        });
+    }
+
+    {
+        let mut orders = world.resource_mut::<Messages<DiplomaticOrder>>();
+        orders.write(DiplomaticOrder {
+            actor: NationId(1),
+            target: NationId(2),
+            kind: DiplomaticOrderKind::DeclareWar,
+        });
+    }
+
+    let _ = world.run_system_once(process_diplomatic_orders);
+
+    let offers = world.resource::<DiplomaticOffers>();
+    let mut defensive_call = offers.iter_for(NationId(3));
+    let defensive = defensive_call.next().expect("defensive call present");
+    match defensive.kind {
+        DiplomaticOfferKind::JoinWar { enemy, defensive } => {
+            assert_eq!(enemy, NationId(1));
+            assert!(defensive);
+        }
+        _ => panic!("expected defensive join war offer"),
+    }
+
+    let mut offensive_call = offers.iter_for(NationId(4));
+    let offensive = offensive_call.next().expect("offensive call present");
+    match offensive.kind {
+        DiplomaticOfferKind::JoinWar { enemy, defensive } => {
+            assert_eq!(enemy, NationId(2));
+            assert!(!defensive);
+        }
+        _ => panic!("expected offensive join war offer"),
+    }
 }
 
 #[test]
@@ -342,4 +495,168 @@ fn accepting_locked_aid_creates_grant() {
             .resource::<ForeignAidLedger>()
             .has_recurring(NationId(1), NationId(2))
     );
+}
+
+#[test]
+fn accepting_defensive_join_war_sets_war() {
+    let mut world = setup_world();
+
+    world.spawn((NationId(1), Name("Aggressor".into()), Treasury::new(1_000)));
+    world.spawn((NationId(2), Name("Ally".into()), Treasury::new(1_000)));
+    world.spawn((NationId(3), Name("Responder".into()), Treasury::new(1_000)));
+
+    world
+        .resource_mut::<DiplomacyState>()
+        .set_treaty(NationId(2), NationId(3), |t| {
+            t.alliance = true;
+            t.non_aggression_pact = true;
+            t.embassy = true;
+        });
+
+    let offer = DiplomaticOffer::new(
+        NationId(2),
+        NationId(3),
+        DiplomaticOfferKind::JoinWar {
+            enemy: NationId(1),
+            defensive: true,
+        },
+    );
+
+    let _ = world.run_system_once(
+        move |mut state: ResMut<DiplomacyState>,
+              mut ledger: ResMut<ForeignAidLedger>,
+              nations: Query<(Entity, &NationId, &Name)>,
+              mut treasuries: Query<&mut Treasury>,
+              mut log: MessageWriter<TerminalLogEvent>| {
+            resolve_offer_response(
+                offer.clone(),
+                true,
+                &mut state,
+                &mut ledger,
+                &nations,
+                &mut treasuries,
+                &mut log,
+            );
+        },
+    );
+
+    let state = world.resource::<DiplomacyState>();
+    let relation = state
+        .relation(NationId(3), NationId(1))
+        .expect("war relation");
+    assert!(relation.treaty.at_war);
+    assert!(relation.score <= -34);
+}
+
+#[test]
+fn declining_defensive_join_war_penalizes() {
+    let mut world = setup_world();
+
+    world.spawn((NationId(1), Name("Aggressor".into()), Treasury::new(1_000)));
+    world.spawn((
+        NationId(2),
+        Name("Attacked Ally".into()),
+        Treasury::new(1_000),
+    ));
+    world.spawn((NationId(3), Name("Refuser".into()), Treasury::new(1_000)));
+    world.spawn((NationId(4), Name("Observer".into()), Treasury::new(1_000)));
+
+    world
+        .resource_mut::<DiplomacyState>()
+        .set_treaty(NationId(2), NationId(3), |t| {
+            t.alliance = true;
+            t.non_aggression_pact = true;
+            t.embassy = true;
+        });
+    world
+        .resource_mut::<DiplomacyState>()
+        .adjust_score(NationId(3), NationId(4), 20);
+
+    let offer = DiplomaticOffer::new(
+        NationId(2),
+        NationId(3),
+        DiplomaticOfferKind::JoinWar {
+            enemy: NationId(1),
+            defensive: true,
+        },
+    );
+
+    let _ = world.run_system_once(
+        move |mut state: ResMut<DiplomacyState>,
+              mut ledger: ResMut<ForeignAidLedger>,
+              nations: Query<(Entity, &NationId, &Name)>,
+              mut treasuries: Query<&mut Treasury>,
+              mut log: MessageWriter<TerminalLogEvent>| {
+            resolve_offer_response(
+                offer.clone(),
+                false,
+                &mut state,
+                &mut ledger,
+                &nations,
+                &mut treasuries,
+                &mut log,
+            );
+        },
+    );
+
+    let state = world.resource::<DiplomacyState>();
+    let alliance_relation = state
+        .relation(NationId(2), NationId(3))
+        .expect("alliance relation");
+    assert!(!alliance_relation.treaty.alliance);
+
+    let observer_relation = state
+        .relation(NationId(3), NationId(4))
+        .expect("observer relation");
+    assert!(observer_relation.score <= 10);
+}
+
+#[test]
+fn declining_offensive_join_war_preserves_alliance() {
+    let mut world = setup_world();
+
+    world.spawn((NationId(1), Name("Aggressor".into()), Treasury::new(1_000)));
+    world.spawn((NationId(2), Name("Target".into()), Treasury::new(1_000)));
+    world.spawn((NationId(3), Name("Ally".into()), Treasury::new(1_000)));
+
+    world
+        .resource_mut::<DiplomacyState>()
+        .set_treaty(NationId(1), NationId(3), |t| {
+            t.alliance = true;
+            t.non_aggression_pact = true;
+            t.embassy = true;
+        });
+
+    let offer = DiplomaticOffer::new(
+        NationId(1),
+        NationId(3),
+        DiplomaticOfferKind::JoinWar {
+            enemy: NationId(2),
+            defensive: false,
+        },
+    );
+
+    let _ = world.run_system_once(
+        move |mut state: ResMut<DiplomacyState>,
+              mut ledger: ResMut<ForeignAidLedger>,
+              nations: Query<(Entity, &NationId, &Name)>,
+              mut treasuries: Query<&mut Treasury>,
+              mut log: MessageWriter<TerminalLogEvent>| {
+            resolve_offer_response(
+                offer.clone(),
+                false,
+                &mut state,
+                &mut ledger,
+                &nations,
+                &mut treasuries,
+                &mut log,
+            );
+        },
+    );
+
+    let state = world.resource::<DiplomacyState>();
+    let relation = state
+        .relation(NationId(1), NationId(3))
+        .expect("alliance relation");
+    assert!(relation.treaty.alliance);
 }


### PR DESCRIPTION
## Summary
- add alliance war call logic that sends join-war demands or invitations and penalizes refusals per the manual
- convert non-aggression pacts into offers that require acceptance instead of instantly applying
- surface the new join-war offer types in the diplomacy UI and cover the flow with unit tests

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68f490c54dfc832f8a1c25f914e0610f