### PR TITLE
Add Imperialism manual buildings and production logic

### DIFF
--- a/src/economy/allocation_systems/mod.rs
+++ b/src/economy/allocation_systems/mod.rs
@@ -60,14 +60,34 @@ pub(crate) fn calculate_inputs_for_one_unit(
             vec![(fiber, 2)]
         }
 
+        BuildingKind::ClothingFactory => {
+            // 2 fabric → 1 clothing
+            vec![(Good::Fabric, 2)]
+        }
+
         BuildingKind::LumberMill => {
             // 2 timber → 1 output (Lumber or Paper)
             vec![(Good::Timber, 2)]
         }
 
+        BuildingKind::FurnitureFactory => {
+            // 2 lumber → 1 furniture
+            vec![(Good::Lumber, 2)]
+        }
+
         BuildingKind::SteelMill => {
             // 1 iron + 1 coal → 1 steel
             vec![(Good::Iron, 1), (Good::Coal, 1)]
+        }
+
+        BuildingKind::MetalWorks => {
+            // 2 steel → 1 hardware or armaments
+            vec![(Good::Steel, 2)]
+        }
+
+        BuildingKind::Refinery => {
+            // 2 oil → 1 fuel
+            vec![(Good::Oil, 2)]
         }
 
         BuildingKind::FoodProcessingCenter => {
@@ -88,6 +108,11 @@ pub(crate) fn calculate_inputs_for_one_unit(
             };
 
             vec![(Good::Grain, 2), (Good::Fruit, 1), (meat, 1)]
+        }
+
+        BuildingKind::Railyard => {
+            // 1 steel + 1 lumber → 1 transport
+            vec![(Good::Steel, 1), (Good::Lumber, 1)]
         }
 
         BuildingKind::Capitol | BuildingKind::TradeSchool | BuildingKind::PowerPlant => vec![],
@@ -180,9 +205,14 @@ fn process_production_adjustment(
 
     let building_kind = match msg.output_good {
         Good::Fabric => BuildingKind::TextileMill,
+        Good::Clothing => BuildingKind::ClothingFactory,
         Good::Paper | Good::Lumber => BuildingKind::LumberMill,
+        Good::Furniture => BuildingKind::FurnitureFactory,
         Good::Steel => BuildingKind::SteelMill,
+        Good::Hardware | Good::Armaments => BuildingKind::MetalWorks,
+        Good::Fuel => BuildingKind::Refinery,
         Good::CannedFood => BuildingKind::FoodProcessingCenter,
+        Good::Transport => BuildingKind::Railyard,
         _ => {
             warn!(
                 "Cannot determine building for output good: {:?}",

--- a/src/economy/allocation_systems/tests.rs
+++ b/src/economy/allocation_systems/tests.rs
@@ -122,6 +122,60 @@ fn test_steel_mill_inputs() {
     assert_eq!(inputs[1], (Good::Coal, 1));
 }
 
+#[test]
+fn test_clothing_factory_inputs() {
+    let stockpile = Stockpile::default();
+
+    let inputs =
+        calculate_inputs_for_one_unit(BuildingKind::ClothingFactory, Good::Clothing, &stockpile);
+
+    assert_eq!(inputs.len(), 1);
+    assert_eq!(inputs[0], (Good::Fabric, 2));
+}
+
+#[test]
+fn test_furniture_factory_inputs() {
+    let stockpile = Stockpile::default();
+
+    let inputs =
+        calculate_inputs_for_one_unit(BuildingKind::FurnitureFactory, Good::Furniture, &stockpile);
+
+    assert_eq!(inputs.len(), 1);
+    assert_eq!(inputs[0], (Good::Lumber, 2));
+}
+
+#[test]
+fn test_metal_works_inputs() {
+    let stockpile = Stockpile::default();
+
+    let inputs =
+        calculate_inputs_for_one_unit(BuildingKind::MetalWorks, Good::Hardware, &stockpile);
+
+    assert_eq!(inputs.len(), 1);
+    assert_eq!(inputs[0], (Good::Steel, 2));
+}
+
+#[test]
+fn test_refinery_inputs() {
+    let stockpile = Stockpile::default();
+
+    let inputs = calculate_inputs_for_one_unit(BuildingKind::Refinery, Good::Fuel, &stockpile);
+
+    assert_eq!(inputs.len(), 1);
+    assert_eq!(inputs[0], (Good::Oil, 2));
+}
+
+#[test]
+fn test_railyard_inputs() {
+    let stockpile = Stockpile::default();
+
+    let inputs = calculate_inputs_for_one_unit(BuildingKind::Railyard, Good::Transport, &stockpile);
+
+    assert_eq!(inputs.len(), 2);
+    assert!(inputs.contains(&(Good::Steel, 1)));
+    assert!(inputs.contains(&(Good::Lumber, 1)));
+}
+
 /// Test reservation system integration
 #[test]
 fn test_reservation_system_basics() {
@@ -289,9 +343,14 @@ fn test_buildings_with_all_initial() {
 
     // Should have all 4 production buildings
     assert!(buildings.get(BuildingKind::TextileMill).is_some());
+    assert!(buildings.get(BuildingKind::ClothingFactory).is_some());
     assert!(buildings.get(BuildingKind::LumberMill).is_some());
+    assert!(buildings.get(BuildingKind::FurnitureFactory).is_some());
     assert!(buildings.get(BuildingKind::SteelMill).is_some());
+    assert!(buildings.get(BuildingKind::MetalWorks).is_some());
+    assert!(buildings.get(BuildingKind::Refinery).is_some());
     assert!(buildings.get(BuildingKind::FoodProcessingCenter).is_some());
+    assert!(buildings.get(BuildingKind::Railyard).is_some());
 
     // Check default capacities
     assert_eq!(
@@ -299,6 +358,34 @@ fn test_buildings_with_all_initial() {
         8
     );
     assert_eq!(buildings.get(BuildingKind::LumberMill).unwrap().capacity, 4);
+    assert_eq!(
+        buildings
+            .get(BuildingKind::ClothingFactory)
+            .unwrap()
+            .capacity,
+        4
+    );
+    assert_eq!(
+        buildings
+            .get(BuildingKind::FurnitureFactory)
+            .unwrap()
+            .capacity,
+        4
+    );
+    assert_eq!(buildings.get(BuildingKind::SteelMill).unwrap().capacity, 4);
+    assert_eq!(buildings.get(BuildingKind::MetalWorks).unwrap().capacity, 4);
+    assert_eq!(buildings.get(BuildingKind::Refinery).unwrap().capacity, 4);
+    assert_eq!(
+        buildings
+            .get(BuildingKind::FoodProcessingCenter)
+            .unwrap()
+            .capacity,
+        4
+    );
+    assert_eq!(
+        buildings.get(BuildingKind::Railyard).unwrap().capacity,
+        u32::MAX
+    );
 }
 
 #[test]

--- a/src/economy/transport/metrics.rs
+++ b/src/economy/transport/metrics.rs
@@ -112,8 +112,12 @@ fn inputs_for_output(
             ProductionChoice::UseWool => vec![(Good::Wool, 2)],
             _ => vec![(Good::Cotton, 2)],
         },
+        BuildingKind::ClothingFactory => vec![(Good::Fabric, 2)],
         BuildingKind::LumberMill => vec![(Good::Timber, 2)],
+        BuildingKind::FurnitureFactory => vec![(Good::Lumber, 2)],
         BuildingKind::SteelMill => vec![(Good::Iron, 1), (Good::Coal, 1)],
+        BuildingKind::MetalWorks => vec![(Good::Steel, 2)],
+        BuildingKind::Refinery => vec![(Good::Oil, 2)],
         BuildingKind::FoodProcessingCenter => {
             let meat = match choice {
                 ProductionChoice::UseFish => Good::Fish,
@@ -122,6 +126,7 @@ fn inputs_for_output(
             // Output is in canned food units (2 per batch)
             vec![(Good::Grain, 2), (Good::Fruit, 1), (meat, 1)]
         }
+        BuildingKind::Railyard => vec![(Good::Steel, 1), (Good::Lumber, 1)],
         BuildingKind::Capitol | BuildingKind::TradeSchool | BuildingKind::PowerPlant => vec![],
     }
 }
@@ -185,9 +190,14 @@ pub fn update_transport_demand_snapshot(
 
             let building_kind = match output_good {
                 Good::Fabric | Good::Cloth => BuildingKind::TextileMill,
+                Good::Clothing => BuildingKind::ClothingFactory,
                 Good::Paper | Good::Lumber => BuildingKind::LumberMill,
+                Good::Furniture => BuildingKind::FurnitureFactory,
                 Good::Steel => BuildingKind::SteelMill,
+                Good::Hardware | Good::Armaments => BuildingKind::MetalWorks,
+                Good::Fuel => BuildingKind::Refinery,
                 Good::CannedFood => BuildingKind::FoodProcessingCenter,
+                Good::Transport => BuildingKind::Railyard,
                 _ => continue,
             };
 
@@ -199,6 +209,7 @@ pub fn update_transport_demand_snapshot(
             let choice = match building_kind {
                 BuildingKind::TextileMill => ProductionChoice::UseCotton,
                 BuildingKind::FoodProcessingCenter => ProductionChoice::UseLivestock,
+                BuildingKind::MetalWorks => ProductionChoice::MakeHardware,
                 _ => ProductionChoice::UseCotton,
             };
 

--- a/src/ui/city/allocation_ui_unified.rs
+++ b/src/ui/city/allocation_ui_unified.rs
@@ -240,9 +240,14 @@ pub fn update_all_allocation_bars(
                 } else {
                     let building_kind = match output_good {
                         Good::Fabric => BuildingKind::TextileMill,
+                        Good::Clothing => BuildingKind::ClothingFactory,
                         Good::Paper | Good::Lumber => BuildingKind::LumberMill,
+                        Good::Furniture => BuildingKind::FurnitureFactory,
                         Good::Steel => BuildingKind::SteelMill,
+                        Good::Hardware | Good::Armaments => BuildingKind::MetalWorks,
+                        Good::Fuel => BuildingKind::Refinery,
                         Good::CannedFood => BuildingKind::FoodProcessingCenter,
+                        Good::Transport => BuildingKind::Railyard,
                         _ => BuildingKind::TextileMill,
                     };
 
@@ -250,13 +255,19 @@ pub fn update_all_allocation_bars(
                         let per_unit_cost = match (building_kind, bar.good) {
                             (BuildingKind::TextileMill, Good::Cotton) => 2,
                             (BuildingKind::TextileMill, Good::Wool) => 2,
+                            (BuildingKind::ClothingFactory, Good::Fabric) => 2,
                             (BuildingKind::LumberMill, Good::Timber) => 2,
+                            (BuildingKind::FurnitureFactory, Good::Lumber) => 2,
                             (BuildingKind::SteelMill, Good::Iron) => 1,
                             (BuildingKind::SteelMill, Good::Coal) => 1,
+                            (BuildingKind::MetalWorks, Good::Steel) => 2,
+                            (BuildingKind::Refinery, Good::Oil) => 2,
                             (BuildingKind::FoodProcessingCenter, Good::Grain) => 2,
                             (BuildingKind::FoodProcessingCenter, Good::Fruit) => 1,
                             (BuildingKind::FoodProcessingCenter, Good::Livestock) => 1,
                             (BuildingKind::FoodProcessingCenter, Good::Fish) => 1,
+                            (BuildingKind::Railyard, Good::Steel) => 1,
+                            (BuildingKind::Railyard, Good::Lumber) => 1,
                             _ => 0,
                         };
                         (count * per_unit_cost, available)

--- a/src/ui/city/buildings/grid.rs
+++ b/src/ui/city/buildings/grid.rs
@@ -93,9 +93,14 @@ pub fn spawn_building_grid(commands: &mut Commands, parent_entity: Entity) {
 
                     // Production buildings
                     spawn_btn(BuildingKind::TextileMill, "Textile\nMill");
+                    spawn_btn(BuildingKind::ClothingFactory, "Clothing\nFactory");
                     spawn_btn(BuildingKind::LumberMill, "Lumber\nMill");
+                    spawn_btn(BuildingKind::FurnitureFactory, "Furniture\nFactory");
                     spawn_btn(BuildingKind::SteelMill, "Steel\nMill");
+                    spawn_btn(BuildingKind::MetalWorks, "Metal\nWorks");
                     spawn_btn(BuildingKind::FoodProcessingCenter, "Food\nProcessing");
+                    spawn_btn(BuildingKind::Refinery, "Oil\nRefinery");
+                    spawn_btn(BuildingKind::Railyard, "Rail\nYard");
 
                     // Workforce buildings
                     spawn_btn(BuildingKind::Capitol, "Capitol");

--- a/src/ui/city/dialogs/systems.rs
+++ b/src/ui/city/dialogs/systems.rs
@@ -36,9 +36,14 @@ pub fn open_building_dialogs(
         // Get dialog title
         let title = match event.building_kind {
             BuildingKind::TextileMill => "Textile Mill",
+            BuildingKind::ClothingFactory => "Clothing Factory",
             BuildingKind::LumberMill => "Lumber Mill",
+            BuildingKind::FurnitureFactory => "Furniture Factory",
             BuildingKind::SteelMill => "Steel Mill",
+            BuildingKind::MetalWorks => "Metal Works",
             BuildingKind::FoodProcessingCenter => "Food Processing",
+            BuildingKind::Refinery => "Oil Refinery",
+            BuildingKind::Railyard => "Railyard",
             BuildingKind::Capitol => "Capitol",
             BuildingKind::TradeSchool => "Trade School",
             BuildingKind::PowerPlant => "Power Plant",


### PR DESCRIPTION
## Summary
- add clothing, furniture, metal, refinery, and railyard buildings with manual-specified recipes
- extend production, allocation, and transport demand logic to support the new industries
- update city UI to surface the extra buildings and add tests covering new inputs

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68f7f360bc10832f844824986aed4e81