### PR TITLE
Ensure MapVisualFor automatically tags map visuals for map visibility systems

### DIFF
--- a/src/civilians/rendering.rs
+++ b/src/civilians/rendering.rs
@@ -6,7 +6,6 @@ use super::types::{Civilian, CivilianJob};
 use crate::assets::civilian_asset_path;
 use crate::map::rendering::{MapVisual, MapVisualFor};
 use crate::map::tile_pos::TilePosExt;
-use crate::ui::components::MapTilemap;
 
 const ENGINEER_SIZE: f32 = 64.0; // Match tile size
 const ENGINEER_SELECTED_COLOR: Color = Color::srgb(1.0, 0.8, 0.0); // Yellow/gold tint for selected units
@@ -48,7 +47,6 @@ pub fn render_civilian_visuals(
                 },
                 Transform::from_translation(pos.extend(3.0)), // Above other visuals
                 MapVisualFor(civilian_entity),                // Relationship: sprite -> civilian
-                MapTilemap,                                   // Marker for visibility control
                 Pickable::default(),
             ))
             .observe(handle_civilian_click);

--- a/src/map/rendering/city_rendering.rs
+++ b/src/map/rendering/city_rendering.rs
@@ -5,7 +5,6 @@ use crate::assets::{capital_asset_path, town_asset_path};
 use crate::map::province::City;
 use crate::map::rendering::{MapVisual, MapVisualFor};
 use crate::map::tile_pos::TilePosExt;
-use crate::ui::components::MapTilemap;
 
 /// Plugin to render city sprites on the map
 pub struct CityRenderingPlugin;
@@ -52,7 +51,6 @@ fn render_city_visuals(
             },
             Transform::from_translation(pos.extend(2.0)), // Below civilians (z=3), above terrain
             MapVisualFor(city_entity),                    // Relationship: sprite -> city
-            MapTilemap,                                   // Marker for visibility control
         ));
     }
 }

--- a/src/map/rendering/map_visual.rs
+++ b/src/map/rendering/map_visual.rs
@@ -1,9 +1,12 @@
 use bevy::prelude::*;
 
+use crate::ui::components::MapTilemap;
+
 /// Points from any map sprite entity to the game entity it visualizes
 /// This is a universal relationship that works for all map entity types:
 /// civilians, cities, depots, ports, regiments, etc.
 #[derive(Component)]
+#[require(MapTilemap)]
 #[relationship(relationship_target = MapVisual)]
 pub struct MapVisualFor(pub Entity);
 

--- a/src/map/rendering/transport_rendering.rs
+++ b/src/map/rendering/transport_rendering.rs
@@ -183,7 +183,6 @@ fn update_depot_visuals(
             },
             Transform::from_translation(pos.extend(2.0)),
             MapVisualFor(depot_entity), // Relationship: sprite -> depot
-            MapTilemap,                 // Marker for visibility control
         ));
     }
 
@@ -246,7 +245,6 @@ fn update_port_visuals(
             },
             Transform::from_translation(pos.extend(2.0)),
             MapVisualFor(port_entity), // Relationship: sprite -> port
-            MapTilemap,                // Marker for visibility control
         ));
     }
 

--- a/src/ui/components.rs
+++ b/src/ui/components.rs
@@ -26,7 +26,7 @@ pub struct CalendarDisplay;
 pub struct TreasuryDisplay;
 
 /// Marker for tilemap entities that should only be visible in Map mode
-#[derive(Component)]
+#[derive(Component, Default)]
 pub struct MapTilemap;
 
 /// Marker for tile info display showing hovered tile information


### PR DESCRIPTION
## Summary
- make `MapVisualFor` require the `MapTilemap` marker so rendered sprites always participate in map visibility control
- derive `Default` for `MapTilemap` to support automatic insertion by the requirement
- remove redundant manual `MapTilemap` inserts from civilian, city, and transport renderers

## Testing
- cargo fmt
- cargo check


------
https://chatgpt.com/codex/tasks/task_b_68f95d1ba7b4832fa4be03518d0c56ee