### PR TITLE
Implement save/load system and persistence tests

### DIFF
--- a/src/ai/behavior.rs
+++ b/src/ai/behavior.rs
@@ -1009,7 +1009,7 @@ mod tests {
     use crate::civilians::types::{
         Civilian, CivilianKind, CivilianOrderKind, ProspectingKnowledge,
     };
-    use crate::economy::nation::Capital;
+    use crate::economy::nation::{Capital, NationId};
     use crate::economy::transport::{Rails, ordered_edge};
     use crate::map::province::{Province, ProvinceId, TileProvince};
     use crate::resources::{DevelopmentLevel, ResourceType, TileResource};
@@ -1018,12 +1018,13 @@ mod tests {
     #[test]
     fn tags_ai_owned_civilians() {
         let mut world = World::new();
-        let ai_nation = world.spawn(AiNation).id();
+        let ai_nation = world.spawn((AiNation, NationId(1))).id();
         let civilian_entity = world
             .spawn(Civilian {
                 kind: CivilianKind::Engineer,
                 position: TilePos { x: 1, y: 1 },
                 owner: ai_nation,
+                owner_id: NationId(1),
                 selected: false,
                 has_moved: false,
             })
@@ -1047,13 +1048,14 @@ mod tests {
     #[test]
     fn removes_tag_from_non_ai_owned_civilians() {
         let mut world = World::new();
-        let player_nation = world.spawn_empty().id();
+        let player_nation = world.spawn(NationId(2)).id();
         let civilian_entity = world
             .spawn((
                 Civilian {
                     kind: CivilianKind::Engineer,
                     position: TilePos { x: 1, y: 1 },
                     owner: player_nation,
+                    owner_id: NationId(2),
                     selected: false,
                     has_moved: false,
                 },
@@ -1086,7 +1088,9 @@ mod tests {
         let improvement_pos = TilePos { x: 3, y: 1 };
         let province_id = ProvinceId(1);
 
-        let ai_nation = world.spawn((AiNation, Capital(capital_pos))).id();
+        let ai_nation = world
+            .spawn((AiNation, NationId(3), Capital(capital_pos)))
+            .id();
 
         {
             let mut rails = world.resource_mut::<Rails>();
@@ -1143,6 +1147,7 @@ mod tests {
                 kind: CivilianKind::Engineer,
                 position: neighbor_pos,
                 owner: ai_nation,
+                owner_id: NationId(3),
                 selected: false,
                 has_moved: false,
             })
@@ -1188,7 +1193,9 @@ mod tests {
         let improvement_pos = TilePos { x: 3, y: 1 };
         let province_id = ProvinceId(1);
 
-        let ai_nation = world.spawn((AiNation, Capital(capital_pos))).id();
+        let ai_nation = world
+            .spawn((AiNation, NationId(4), Capital(capital_pos)))
+            .id();
 
         {
             let mut rails = world.resource_mut::<Rails>();
@@ -1245,6 +1252,7 @@ mod tests {
                 kind: CivilianKind::Engineer,
                 position: capital_pos,
                 owner: ai_nation,
+                owner_id: NationId(4),
                 selected: false,
                 has_moved: false,
             })
@@ -1307,7 +1315,7 @@ mod tests {
     #[test]
     fn selects_owned_neighbor_as_move_target() {
         let mut world = World::new();
-        let ai_nation = world.spawn(AiNation).id();
+        let ai_nation = world.spawn((AiNation, NationId(5))).id();
         let neighbor_pos = TilePos { x: 2, y: 1 };
         let mut storage = TileStorage::empty(TilemapSize { x: 4, y: 4 });
 
@@ -1329,6 +1337,7 @@ mod tests {
             kind: CivilianKind::Engineer,
             position: TilePos { x: 1, y: 1 },
             owner: ai_nation,
+            owner_id: NationId(5),
             selected: false,
             has_moved: false,
         };
@@ -1357,7 +1366,9 @@ mod tests {
         world.insert_resource(ProspectingKnowledge::default());
 
         let capital_pos = TilePos { x: 1, y: 1 };
-        let ai_nation = world.spawn((AiNation, Capital(capital_pos))).id();
+        let ai_nation = world
+            .spawn((AiNation, NationId(6), Capital(capital_pos)))
+            .id();
 
         let mut storage = TileStorage::empty(TilemapSize { x: 4, y: 4 });
         let province_id = ProvinceId(1);
@@ -1390,6 +1401,7 @@ mod tests {
             kind: CivilianKind::Farmer,
             position: capital_pos,
             owner: ai_nation,
+            owner_id: NationId(6),
             selected: false,
             has_moved: false,
         };
@@ -1426,7 +1438,9 @@ mod tests {
         world.insert_resource(ProspectingKnowledge::default());
 
         let capital_pos = TilePos { x: 1, y: 1 };
-        let ai_nation = world.spawn((AiNation, Capital(capital_pos))).id();
+        let ai_nation = world
+            .spawn((AiNation, NationId(7), Capital(capital_pos)))
+            .id();
 
         let mut storage = TileStorage::empty(TilemapSize { x: 4, y: 4 });
         let province_id = ProvinceId(1);
@@ -1459,6 +1473,7 @@ mod tests {
             kind: CivilianKind::Miner,
             position: capital_pos,
             owner: ai_nation,
+            owner_id: NationId(7),
             selected: false,
             has_moved: false,
         };
@@ -1495,7 +1510,9 @@ mod tests {
         world.insert_resource(ProspectingKnowledge::default());
 
         let capital_pos = TilePos { x: 1, y: 1 };
-        let ai_nation = world.spawn((AiNation, Capital(capital_pos))).id();
+        let ai_nation = world
+            .spawn((AiNation, NationId(8), Capital(capital_pos)))
+            .id();
 
         let mut storage = TileStorage::empty(TilemapSize { x: 4, y: 4 });
         let province_id = ProvinceId(1);
@@ -1533,6 +1550,7 @@ mod tests {
             kind: CivilianKind::Miner,
             position: capital_pos,
             owner: ai_nation,
+            owner_id: NationId(8),
             selected: false,
             has_moved: false,
         };

--- a/src/ai/markers.rs
+++ b/src/ai/markers.rs
@@ -1,9 +1,11 @@
 use bevy::prelude::*;
 
 /// Marks a nation entity that should be driven by the AI turn systems.
-#[derive(Component, Debug, Default)]
+#[derive(Component, Debug, Default, Reflect)]
+#[reflect(Component)]
 pub struct AiNation;
 
 /// Marks a civilian unit that is controlled by the AI.
-#[derive(Component, Debug, Default)]
+#[derive(Component, Debug, Default, Reflect)]
+#[reflect(Component)]
 pub struct AiControlledCivilian;

--- a/src/civilians/order_validation.rs
+++ b/src/civilians/order_validation.rs
@@ -152,6 +152,7 @@ mod tests {
     use bevy_ecs_tilemap::prelude::{TilePos, TileStorage, TilemapSize};
 
     use crate::civilians::order_validation::validate_command;
+    use crate::economy::nation::NationId;
     use crate::map::province::{Province, ProvinceId, TileProvince};
 
     #[test]
@@ -174,6 +175,7 @@ mod tests {
             kind: CivilianKind::Prospector,
             position: tile_pos,
             owner: Entity::PLACEHOLDER,
+            owner_id: NationId(0),
             selected: false,
             has_moved: false,
         };

--- a/src/civilians/player_ownership_test.rs
+++ b/src/civilians/player_ownership_test.rs
@@ -28,6 +28,7 @@ fn test_cannot_select_enemy_units() {
             kind: CivilianKind::Engineer,
             position: TilePos { x: 0, y: 0 },
             owner: enemy_nation_entity,
+            owner_id: NationId(2),
             selected: false,
             has_moved: false,
         })
@@ -83,6 +84,7 @@ fn test_can_select_own_units() {
             kind: CivilianKind::Engineer,
             position: TilePos { x: 0, y: 0 },
             owner: player_nation_entity,
+            owner_id: NationId(1),
             selected: false,
             has_moved: false,
         })
@@ -138,6 +140,7 @@ fn test_selecting_player_unit_deselects_others() {
             kind: CivilianKind::Engineer,
             position: TilePos { x: 0, y: 0 },
             owner: player_nation_entity,
+            owner_id: NationId(1),
             selected: true, // Already selected
             has_moved: false,
         })
@@ -149,6 +152,7 @@ fn test_selecting_player_unit_deselects_others() {
             kind: CivilianKind::Prospector,
             position: TilePos { x: 1, y: 1 },
             owner: player_nation_entity,
+            owner_id: NationId(1),
             selected: false,
             has_moved: false,
         })

--- a/src/civilians/types.rs
+++ b/src/civilians/types.rs
@@ -2,12 +2,16 @@ use bevy::ecs::entity::{EntityMapper, MapEntities};
 use bevy::ecs::reflect::ReflectMapEntities;
 use bevy::prelude::*;
 use bevy_ecs_tilemap::prelude::TilePos;
+use moonshine_save::prelude::Save;
 use std::collections::{HashMap, HashSet};
+use std::mem;
 
+use crate::economy::nation::NationId;
 use crate::resources::TileResource;
 
 /// Tracks which nations have successfully prospected each mineral tile
-#[derive(Resource, Default, Debug)]
+#[derive(Resource, Default, Debug, Reflect)]
+#[reflect(Resource, MapEntities)]
 pub struct ProspectingKnowledge {
     discoveries: HashMap<Entity, HashSet<Entity>>,
 }
@@ -35,6 +39,23 @@ impl ProspectingKnowledge {
         for nations in self.discoveries.values_mut() {
             nations.remove(&nation);
         }
+    }
+}
+
+impl MapEntities for ProspectingKnowledge {
+    fn map_entities<M: EntityMapper>(&mut self, mapper: &mut M) {
+        let discoveries = mem::take(&mut self.discoveries);
+        self.discoveries = discoveries
+            .into_iter()
+            .map(|(tile, nations)| {
+                let mapped_tile = mapper.get_mapped(tile);
+                let mapped_nations = nations
+                    .into_iter()
+                    .map(|nation| mapper.get_mapped(nation))
+                    .collect();
+                (mapped_tile, mapped_nations)
+            })
+            .collect();
     }
 }
 
@@ -307,10 +328,12 @@ impl CivilianKind {
 /// Civilian unit component
 #[derive(Component, Debug, Reflect)]
 #[reflect(Component, MapEntities)]
+#[require(Save)]
 pub struct Civilian {
     pub kind: CivilianKind,
     pub position: TilePos,
     pub owner: Entity, // Nation entity that owns this unit
+    pub owner_id: NationId,
     pub selected: bool,
     pub has_moved: bool, // True if unit has used its action this turn
 }

--- a/src/economy/calendar.rs
+++ b/src/economy/calendar.rs
@@ -1,6 +1,7 @@
 use bevy::prelude::*;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Reflect)]
+#[reflect(Debug)]
 pub enum Season {
     Spring,
     Summer,
@@ -19,7 +20,8 @@ impl core::fmt::Display for Season {
     }
 }
 
-#[derive(Resource, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Resource, Debug, Clone, Copy, PartialEq, Eq, Reflect)]
+#[reflect(Resource)]
 pub struct Calendar {
     pub season: Season,
     pub year: u16,

--- a/src/economy/goods.rs
+++ b/src/economy/goods.rs
@@ -1,6 +1,7 @@
+use bevy::prelude::Reflect;
 use core::fmt;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd, Reflect)]
 pub enum Good {
     // Raw food resources
     Grain,

--- a/src/economy/nation.rs
+++ b/src/economy/nation.rs
@@ -1,14 +1,17 @@
 use bevy::prelude::*;
 use bevy_ecs_tilemap::prelude::TilePos;
 use moonshine_kind::Instance;
+use moonshine_save::prelude::Save;
 
 /// Unique identifier for a nation (stable across saves)
 #[derive(Component, Clone, Copy, Debug, Eq, PartialEq, Hash, Reflect)]
 #[reflect(Component)]
+#[require(Save)]
 pub struct NationId(pub u16);
 
 /// Display name for a nation
-#[derive(Component, Clone, Debug)]
+#[derive(Component, Clone, Debug, Reflect)]
+#[reflect(Component)]
 pub struct Name(pub String);
 
 /// Type-safe handle to a nation entity.
@@ -29,7 +32,8 @@ impl NationHandle {
 }
 
 /// Capital tile position for a nation (used for rail network connectivity)
-#[derive(Component, Clone, Copy, Debug)]
+#[derive(Component, Clone, Copy, Debug, Reflect)]
+#[reflect(Component)]
 pub struct Capital(pub TilePos);
 
 /// Resource pointing to the player's active nation entity
@@ -65,7 +69,8 @@ impl PlayerNation {
 }
 
 /// Nation display color (for borders and UI)
-#[derive(Component, Clone, Copy, Debug)]
+#[derive(Component, Clone, Copy, Debug, Reflect)]
+#[reflect(Component)]
 pub struct NationColor(pub Color);
 
 #[cfg(test)]

--- a/src/economy/production.rs
+++ b/src/economy/production.rs
@@ -345,7 +345,7 @@ mod tests {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect)]
 pub enum BuildingKind {
     // Production buildings
     TextileMill,          // 2×Cotton OR 2×Wool → 1×Fabric
@@ -365,7 +365,7 @@ pub enum BuildingKind {
 }
 
 /// What input material a building should use for production
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Reflect)]
 pub enum ProductionChoice {
     // For TextileMill: choose between Cotton or Wool
     UseCotton,
@@ -385,7 +385,8 @@ pub enum ProductionChoice {
 }
 
 /// Production settings for a building (persists turn-to-turn)
-#[derive(Component, Debug, Clone)]
+#[derive(Component, Debug, Clone, Reflect)]
+#[reflect(Component)]
 pub struct ProductionSettings {
     /// What input material to use (e.g., Cotton vs Wool for textile mill)
     pub choice: ProductionChoice,
@@ -402,7 +403,8 @@ impl Default for ProductionSettings {
     }
 }
 
-#[derive(Component, Debug, Clone, Copy)]
+#[derive(Component, Debug, Clone, Copy, Reflect)]
+#[reflect(Component)]
 pub struct Building {
     pub kind: BuildingKind,
     pub capacity: u32, // Maximum output per turn
@@ -888,7 +890,8 @@ pub fn input_requirement_per_unit(
 }
 
 /// Collection of all buildings for a nation
-#[derive(Component, Debug, Clone, Default)]
+#[derive(Component, Debug, Clone, Default, Reflect)]
+#[reflect(Component)]
 pub struct Buildings {
     pub buildings: HashMap<BuildingKind, Building>,
 }

--- a/src/economy/reservation.rs
+++ b/src/economy/reservation.rs
@@ -4,7 +4,8 @@ use std::collections::HashMap;
 use crate::economy::goods::Good;
 
 /// A pool of resources with reservations
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Reflect)]
+#[reflect(Debug)]
 pub struct ResourcePool {
     pub total: u32,
     pub reserved: u32,
@@ -44,11 +45,11 @@ impl ResourcePool {
 }
 
 /// Opaque identifier for a reservation
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug, Reflect)]
 pub struct ReservationId(u32);
 
 /// Internal data for a reservation
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Reflect)]
 struct ReservationData {
     goods: Vec<(Good, u32)>,
     labor: u32,

--- a/src/economy/stockpile.rs
+++ b/src/economy/stockpile.rs
@@ -13,7 +13,8 @@ pub struct StockpileEntry {
     pub available: u32,
 }
 
-#[derive(Component, Debug, Clone, Default)]
+#[derive(Component, Debug, Clone, Default, Reflect)]
+#[reflect(Component)]
 pub struct Stockpile {
     pools: HashMap<Good, ResourcePool>,
 }

--- a/src/economy/technology.rs
+++ b/src/economy/technology.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use std::collections::HashSet;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect)]
 pub enum Technology {
     // Rail construction technologies
     MountainEngineering, // Allows building rails in mountains
@@ -10,7 +10,8 @@ pub enum Technology {
 }
 
 /// Set of technologies owned by a nation
-#[derive(Component, Debug, Default, Clone)]
+#[derive(Component, Debug, Default, Clone, Reflect)]
+#[reflect(Component)]
 pub struct Technologies(pub HashSet<Technology>);
 
 impl Technologies {

--- a/src/economy/transport/types.rs
+++ b/src/economy/transport/types.rs
@@ -2,6 +2,7 @@ use bevy::ecs::entity::{EntityMapper, MapEntities};
 use bevy::ecs::reflect::ReflectMapEntities;
 use bevy::prelude::*;
 use bevy_ecs_tilemap::prelude::TilePos;
+use moonshine_save::prelude::Save;
 use std::collections::HashSet;
 
 /// Type of transport improvement
@@ -16,6 +17,7 @@ pub enum ImprovementKind {
 /// Marker component for depots that gather resources
 #[derive(Component, Debug, Reflect)]
 #[reflect(Component, MapEntities)]
+#[require(Save)]
 pub struct Depot {
     pub position: TilePos,
     pub owner: Entity,   // Nation entity that owns this depot
@@ -25,6 +27,7 @@ pub struct Depot {
 /// Marker component for ports (coastal or river)
 #[derive(Component, Debug, Reflect)]
 #[reflect(Component, MapEntities)]
+#[require(Save)]
 pub struct Port {
     pub position: TilePos,
     pub owner: Entity, // Nation entity that owns this port
@@ -45,6 +48,7 @@ pub struct Rails(pub HashSet<(TilePos, TilePos)>);
 /// Component tracking rail construction in progress (takes 3 turns to complete)
 #[derive(Component, Debug, Reflect)]
 #[reflect(Component, MapEntities)]
+#[require(Save)]
 pub struct RailConstruction {
     pub from: TilePos,
     pub to: TilePos,

--- a/src/economy/treasury.rs
+++ b/src/economy/treasury.rs
@@ -2,7 +2,8 @@ use bevy::prelude::*;
 
 use crate::economy::reservation::ResourcePool;
 
-#[derive(Component, Debug, Clone)]
+#[derive(Component, Debug, Clone, Reflect)]
+#[reflect(Component)]
 pub struct Treasury {
     money_pool: ResourcePool,
 }

--- a/src/economy/workforce/recruitment.rs
+++ b/src/economy/workforce/recruitment.rs
@@ -9,7 +9,8 @@ use crate::messages::workforce::RecruitWorkers;
 use crate::turn_system::{TurnPhase, TurnSystem};
 
 /// Component tracking queued recruitment orders for a nation
-#[derive(Component, Debug, Clone, Default)]
+#[derive(Component, Debug, Clone, Default, Reflect)]
+#[reflect(Component)]
 pub struct RecruitmentQueue {
     /// Number of workers queued for recruitment this turn
     pub queued: u32,

--- a/src/economy/workforce/training.rs
+++ b/src/economy/workforce/training.rs
@@ -8,7 +8,8 @@ use crate::messages::workforce::TrainWorker;
 use crate::turn_system::{TurnPhase, TurnSystem};
 
 /// Component tracking queued training orders for a nation
-#[derive(Component, Debug, Clone, Default)]
+#[derive(Component, Debug, Clone, Default, Reflect)]
+#[reflect(Component)]
 pub struct TrainingQueue {
     /// Training orders: (from_skill, count)
     pub orders: Vec<(WorkerSkill, u32)>,

--- a/src/economy/workforce/types.rs
+++ b/src/economy/workforce/types.rs
@@ -5,7 +5,8 @@ use crate::economy::reservation::ResourcePool;
 
 /// Workforce component tracks workers by skill level for a nation
 /// Workers provide labor points: Untrained=1, Trained=2, Expert=4
-#[derive(Component, Debug, Clone, Default)]
+#[derive(Component, Debug, Clone, Default, Reflect)]
+#[reflect(Component)]
 pub struct Workforce {
     /// Individual workers with their state
     pub workers: Vec<Worker>,
@@ -139,7 +140,7 @@ impl Workforce {
 }
 
 /// Individual worker with skill level and health state
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Reflect)]
 pub struct Worker {
     pub skill: WorkerSkill,
     pub health: WorkerHealth,
@@ -148,7 +149,7 @@ pub struct Worker {
 }
 
 /// Worker skill level determines labor points
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect)]
 pub enum WorkerSkill {
     Untrained, // 1 labor point
     Trained,   // 2 labor points
@@ -176,7 +177,7 @@ impl WorkerSkill {
 }
 
 /// Worker health state
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Reflect)]
 pub enum WorkerHealth {
     Healthy, // Produces labor
     Sick,    // Ate wrong food, produces 0 labor
@@ -184,7 +185,8 @@ pub enum WorkerHealth {
 }
 
 /// Component to track recruitment upgrades
-#[derive(Component, Debug, Clone, Copy, Default)]
+#[derive(Component, Debug, Clone, Copy, Default, Reflect)]
+#[reflect(Component)]
 pub struct RecruitmentCapacity {
     pub upgraded: bool, // false = provinces/4, true = provinces/3
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ use crate::map::rendering::prospecting_markers::ProspectingMarkersPlugin;
 use crate::map::rendering::{
     ConnectedResourceDebugPlugin, TransportDebugPlugin, TransportRenderingPlugin,
 };
+use crate::save::GameSavePlugin;
 use crate::turn_system::TurnSystemPlugin;
 use crate::ui::GameUIPlugin;
 use crate::ui::menu::AppState;
@@ -84,6 +85,7 @@ pub fn app() -> App {
             ImprovementRenderingPlugin,
             ProspectingMarkersPlugin,
         ))
+        .add_plugins(GameSavePlugin)
         .add_plugins(AiBehaviorPlugin);
 
     app

--- a/src/map/province.rs
+++ b/src/map/province.rs
@@ -2,6 +2,7 @@ use bevy::ecs::entity::{EntityMapper, MapEntities};
 use bevy::ecs::reflect::ReflectMapEntities;
 use bevy::prelude::*;
 use bevy_ecs_tilemap::prelude::TilePos;
+use moonshine_save::prelude::Save;
 
 /// Unique identifier for a province
 #[derive(Component, Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect)]
@@ -11,6 +12,7 @@ pub struct ProvinceId(pub u32);
 /// A province is a collection of adjacent tiles with one city
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component, MapEntities)]
+#[require(Save)]
 pub struct Province {
     pub id: ProvinceId,
     pub tiles: Vec<TilePos>,
@@ -21,6 +23,7 @@ pub struct Province {
 /// Marker component for the city within a province
 #[derive(Component, Debug, Clone, Copy, Reflect)]
 #[reflect(Component)]
+#[require(Save)]
 pub struct City {
     pub province: ProvinceId,
     pub is_capital: bool,

--- a/src/map/province_setup.rs
+++ b/src/map/province_setup.rs
@@ -18,7 +18,8 @@ use crate::map::tiles::TerrainType;
 use crate::resources::{DevelopmentLevel, TileResource};
 
 /// Resource to track if provinces have been generated
-#[derive(Resource)]
+#[derive(Resource, Reflect, Default)]
+#[reflect(Resource)]
 pub struct ProvincesGenerated;
 
 /// Generate provinces after the tilemap is created
@@ -92,7 +93,7 @@ pub fn assign_provinces_to_countries(
     ];
 
     // Create countries
-    let mut country_entities = Vec::new();
+    let mut country_entities: Vec<(Entity, NationId)> = Vec::new();
     let mut capitals = Vec::new();
 
     for i in 0..num_countries {
@@ -181,12 +182,12 @@ pub fn assign_provinces_to_countries(
             // Note: Capitol and TradeSchool don't need separate Building entities
             // They're always available and use the nation's Stockpile/Workforce directly
         }
-        country_entities.push(country_entity);
+        country_entities.push((country_entity, NationId(i as u16 + 1)));
         info!("Created Nation {} with color", i + 1);
     }
 
     // Set player nation reference
-    if let Some(&player_entity) = country_entities.first() {
+    if let Some(&(player_entity, _)) = country_entities.first() {
         commands.queue(move |world: &mut World| {
             if let Some(player_nation) = PlayerNation::from_entity(world, player_entity) {
                 world.insert_resource(player_nation);
@@ -216,7 +217,7 @@ pub fn assign_provinces_to_countries(
             province_list.len() / num_countries,
         );
 
-        let country_entity = country_entities[country_idx % num_countries];
+        let (country_entity, _) = country_entities[country_idx % num_countries];
 
         // Assign all provinces in the connected group to this country
         for &prov_id in &connected_group {
@@ -244,7 +245,7 @@ pub fn assign_provinces_to_countries(
     // Handle any remaining unassigned provinces
     for (province_entity, province_id, city_tile) in province_list.iter() {
         if !assigned.contains(province_id) {
-            let country_entity = country_entities[country_idx % num_countries];
+            let (country_entity, _) = country_entities[country_idx % num_countries];
             assign_province_to_country(
                 &mut commands,
                 &mut provinces,
@@ -259,10 +260,12 @@ pub fn assign_provinces_to_countries(
         }
     }
 
-    let player_entity = country_entities.first().copied();
+    let nation_ids: HashMap<Entity, NationId> = country_entities.iter().copied().collect();
+    let player_info = country_entities.first().copied();
+    let player_entity_only = player_info.map(|(entity, _)| entity);
 
     // Spawn starter civilian roster for the player clustered around the capital
-    if let Some(player_entity) = player_entity
+    if let Some((player_entity, player_id)) = player_info
         && let Some(player_capital) = capitals
             .iter()
             .find(|(entity, _)| *entity == player_entity)
@@ -283,6 +286,7 @@ pub fn assign_provinces_to_countries(
                 kind: *kind,
                 position: *pos,
                 owner: player_entity,
+                owner_id: player_id,
                 selected: false,
                 has_moved: false,
             });
@@ -301,15 +305,20 @@ pub fn assign_provinces_to_countries(
     for (nation_entity, capital_pos) in capitals
         .iter()
         .copied()
-        .filter(|(entity, _)| Some(*entity) != player_entity)
+        .filter(|(entity, _)| Some(*entity) != player_entity_only)
     {
         let spawn_positions = gather_spawn_positions(capital_pos, ai_starter_units.len());
         for (kind, pos) in ai_starter_units.iter().zip(spawn_positions.iter()) {
+            let owner_id = nation_ids
+                .get(&nation_entity)
+                .copied()
+                .unwrap_or(NationId(0));
             commands.spawn((
                 Civilian {
                     kind: *kind,
                     position: *pos,
                     owner: nation_entity,
+                    owner_id,
                     selected: false,
                     has_moved: false,
                 },

--- a/src/turn_system.rs
+++ b/src/turn_system.rs
@@ -3,13 +3,14 @@ use bevy::prelude::*;
 use crate::diplomacy::DiplomaticOffers;
 use crate::economy::{Calendar, NationId, PlayerNation, Season};
 
-#[derive(Resource, Debug, Clone)]
+#[derive(Resource, Debug, Clone, Reflect)]
+#[reflect(Resource)]
 pub struct TurnSystem {
     pub current_turn: u32,
     pub phase: TurnPhase,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Reflect)]
 pub enum TurnPhase {
     PlayerTurn,
     Processing,

--- a/src/ui/city/workforce.rs
+++ b/src/ui/city/workforce.rs
@@ -22,7 +22,7 @@ pub fn spawn_hired_civilian(
     mut commands: Commands,
     mut hire_events: MessageReader<HireCivilian>,
     player_nation: Option<Res<PlayerNation>>,
-    nations: Query<&Capital>,
+    nations: Query<(&Capital, &crate::economy::nation::NationId)>,
     mut treasuries: Query<&mut Treasury>,
     tile_storage_query: Query<&bevy_ecs_tilemap::prelude::TileStorage>,
     civilians: Query<&Civilian>,
@@ -33,7 +33,7 @@ pub fn spawn_hired_civilian(
         };
 
         // Get capital position
-        let Ok(capital) = nations.get(player.entity()) else {
+        let Ok((capital, nation_id)) = nations.get(player.entity()) else {
             info!("Cannot hire: no capital found");
             continue;
         };
@@ -78,6 +78,7 @@ pub fn spawn_hired_civilian(
             kind: event.kind,
             position: spawn_pos,
             owner: player.entity(),
+            owner_id: *nation_id,
             selected: false,
             has_moved: false,
         });

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2,6 +2,8 @@
 //!
 //! These tests demonstrate ECS testing patterns and verify core game mechanics
 
+use rust_imperialism::economy::nation::NationId;
+
 /// Test turn system functionality
 #[test]
 fn test_turn_system() {
@@ -70,6 +72,7 @@ fn test_ai_move_command_executes() {
     use rust_imperialism::civilians::{
         Civilian, CivilianCommand, CivilianKind, CivilianOrder, CivilianOrderKind, DeselectCivilian,
     };
+    use rust_imperialism::economy::nation::NationId;
     use rust_imperialism::map::province::{Province, ProvinceId, TileProvince};
     use rust_imperialism::messages::civilians::CivilianCommandRejected;
     use rust_imperialism::turn_system::TurnSystem;
@@ -81,7 +84,7 @@ fn test_ai_move_command_executes() {
     world.init_resource::<Messages<DeselectCivilian>>();
 
     // Owned province and tiles
-    let nation = world.spawn_empty().id();
+    let nation = world.spawn(NationId(1)).id();
     let province_id = ProvinceId(1);
     world.spawn(Province {
         id: province_id,
@@ -104,6 +107,7 @@ fn test_ai_move_command_executes() {
             kind: CivilianKind::Engineer,
             position: start,
             owner: nation,
+            owner_id: NationId(1),
             selected: false,
             has_moved: false,
         })
@@ -159,7 +163,7 @@ fn test_illegal_rail_command_rejected() {
     world.init_resource::<Messages<CivilianCommandRejected>>();
     world.init_resource::<Messages<DeselectCivilian>>();
 
-    let player = world.spawn_empty().id();
+    let player = world.spawn(NationId(2)).id();
     let other = world.spawn_empty().id();
 
     let player_province = ProvinceId(1);
@@ -199,6 +203,7 @@ fn test_illegal_rail_command_rejected() {
             kind: CivilianKind::Engineer,
             position: start,
             owner: player,
+            owner_id: NationId(2),
             selected: false,
             has_moved: false,
         })


### PR DESCRIPTION
## Summary
- integrate the moonshine_save pipeline into the game, registering reflective data, persisting resources, and rebuilding runtime state (including civilian owner remapping) after loads
- add a persistent `owner_id` to civilians so their owning nation can be restored, updating spawns/tests accordingly
- cover the save/load flow with unit and integration tests that write, reload, and validate core game state

## Testing
- `cargo test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6918bcc7cde0832f879edb17c8f87957)