### PR TITLE
Add macro AI analysis pipeline and buffered order queue

### DIFF
--- a/src/ai/markers.rs
+++ b/src/ai/markers.rs
@@ -1,9 +1,11 @@
 use bevy::prelude::*;
 
+use crate::economy::nation::NationId;
+
 /// Marks a nation entity that should be driven by the AI turn systems.
-#[derive(Component, Debug, Default, Reflect)]
+#[derive(Component, Debug, Clone, Copy, Reflect)]
 #[reflect(Component)]
-pub struct AiNation;
+pub struct AiNation(pub NationId);
 
 /// Marks a civilian unit that is controlled by the AI.
 #[derive(Component, Debug, Default, Reflect)]

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -9,9 +9,12 @@ pub mod trade;
 
 pub use behavior::AiBehaviorPlugin;
 pub use context::{
-    AiAllocationSnapshot, AiMarketBuy, AiNationSnapshot, AiStockpileEntry, AiTransportAllocation,
-    AiTransportDemand, AiTransportSnapshot, AiTurnContext, AiWorkforceSnapshot, enemy_turn_entered,
-    populate_ai_turn_context,
+    AiAllocationSnapshot, AiMarketBuy, AiNationSnapshot, AiPlanLedger, AiStockpileEntry,
+    AiTransportAllocation, AiTransportDemand, AiTransportSnapshot, AiTurnContext,
+    AiWorkforceSnapshot, BeliefState, MacroActionCandidate, MacroTag, MarketView, MinorId,
+    TransportAnalysis, TurnCandidates, enemy_turn_entered, gather_turn_candidates,
+    populate_ai_turn_context, update_belief_state_system, update_market_view_system,
+    update_transport_analysis_system,
 };
 pub use markers::{AiControlledCivilian, AiNation};
 pub use trade::AiEconomyPlugin;
@@ -21,11 +24,17 @@ pub struct AiSupportPlugin;
 
 impl Plugin for AiSupportPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<AiTurnContext>().add_systems(
-            Update,
-            populate_ai_turn_context
-                .run_if(in_state(AppState::InGame))
-                .run_if(enemy_turn_entered),
-        );
+        app.init_resource::<AiTurnContext>()
+            .init_resource::<BeliefState>()
+            .init_resource::<MarketView>()
+            .init_resource::<TransportAnalysis>()
+            .init_resource::<TurnCandidates>()
+            .init_resource::<AiPlanLedger>()
+            .add_systems(
+                Update,
+                populate_ai_turn_context
+                    .run_if(in_state(AppState::InGame))
+                    .run_if(enemy_turn_entered),
+            );
     }
 }

--- a/src/economy/allocation_systems/mod.rs
+++ b/src/economy/allocation_systems/mod.rs
@@ -1,3 +1,4 @@
+use bevy::ecs::message::{MessageReader, MessageWriter};
 use bevy::prelude::*;
 
 use crate::economy::{
@@ -6,6 +7,7 @@ use crate::economy::{
     production::{BuildingKind, Buildings, building_for_output},
     reservation::ReservationSystem,
     stockpile::Stockpile,
+    transport::PlaceImprovement,
     treasury::Treasury,
     workforce::{RecruitmentCapacity, types::*},
 };
@@ -512,6 +514,20 @@ pub fn execute_queued_market_orders(
 
     for order in queued {
         process_market_adjustment(order, &mut nations);
+    }
+}
+
+pub fn execute_queued_transport_orders(
+    mut orders: ResMut<OrdersQueue>,
+    mut writer: MessageWriter<PlaceImprovement>,
+) {
+    let queued = orders.take_transport();
+    if queued.is_empty() {
+        return;
+    }
+
+    for order in queued {
+        writer.write(order);
     }
 }
 

--- a/src/economy/mod.rs
+++ b/src/economy/mod.rs
@@ -120,6 +120,7 @@ impl Plugin for EconomyPlugin {
                 allocation_systems::execute_queued_recruitment_orders,
                 allocation_systems::execute_queued_training_orders,
                 allocation_systems::execute_queued_production_orders,
+                allocation_systems::execute_queued_transport_orders,
                 allocation_systems::execute_queued_market_orders,
             )
                 .chain()

--- a/src/map/province_setup.rs
+++ b/src/map/province_setup.rs
@@ -104,11 +104,12 @@ pub fn assign_provinces_to_countries(
         };
 
         let stockpile = baseline_stockpile();
+        let nation_id = NationId(i as u16 + 1);
 
         let color = nation_colors[i % nation_colors.len()];
 
         let country_builder = commands.spawn((
-            NationId(i as u16 + 1),
+            nation_id,
             Name(name),
             NationColor(color),
             Treasury::new(10_000),
@@ -131,7 +132,7 @@ pub fn assign_provinces_to_countries(
         });
 
         if i > 0 {
-            commands.entity(country_entity).insert(AiNation);
+            commands.entity(country_entity).insert(AiNation(nation_id));
         }
 
         // Give every nation a basic industrial base so AI economies can function
@@ -151,7 +152,7 @@ pub fn assign_provinces_to_countries(
 
         // Note: Capitol and TradeSchool don't need separate Building entities
         // They're always available and use the nation's Stockpile/Workforce directly
-        country_entities.push((country_entity, NationId(i as u16 + 1)));
+        country_entities.push((country_entity, nation_id));
         info!("Created Nation {} with color", i + 1);
     }
 

--- a/src/orders/mod.rs
+++ b/src/orders/mod.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 
+use crate::economy::transport::PlaceImprovement;
 use crate::messages::{AdjustMarketOrder, AdjustProduction, AdjustRecruitment, AdjustTraining};
 
 /// Queue of structured orders emitted during a nation's turn.
@@ -12,6 +13,7 @@ pub struct OrdersQueue {
     recruitment: Vec<AdjustRecruitment>,
     training: Vec<AdjustTraining>,
     market: Vec<AdjustMarketOrder>,
+    transport: Vec<PlaceImprovement>,
 }
 
 impl OrdersQueue {
@@ -31,6 +33,10 @@ impl OrdersQueue {
         self.market.push(order);
     }
 
+    pub fn queue_transport(&mut self, order: PlaceImprovement) {
+        self.transport.push(order);
+    }
+
     pub fn take_production(&mut self) -> Vec<AdjustProduction> {
         std::mem::take(&mut self.production)
     }
@@ -47,11 +53,16 @@ impl OrdersQueue {
         std::mem::take(&mut self.market)
     }
 
+    pub fn take_transport(&mut self) -> Vec<PlaceImprovement> {
+        std::mem::take(&mut self.transport)
+    }
+
     pub fn is_empty(&self) -> bool {
         self.production.is_empty()
             && self.recruitment.is_empty()
             && self.training.is_empty()
             && self.market.is_empty()
+            && self.transport.is_empty()
     }
 
     pub fn clear(&mut self) {
@@ -59,15 +70,78 @@ impl OrdersQueue {
         self.recruitment.clear();
         self.training.clear();
         self.market.clear();
+        self.transport.clear();
+    }
+}
+
+/// Buffer for AI-generated orders that need to be merged into the global queue.
+#[derive(Resource, Default, Debug)]
+pub struct OrdersOut {
+    production: Vec<AdjustProduction>,
+    recruitment: Vec<AdjustRecruitment>,
+    training: Vec<AdjustTraining>,
+    market: Vec<AdjustMarketOrder>,
+    transport: Vec<PlaceImprovement>,
+}
+
+impl OrdersOut {
+    pub fn queue_market(&mut self, order: AdjustMarketOrder) {
+        self.market.push(order);
+    }
+
+    pub fn queue_transport(&mut self, order: PlaceImprovement) {
+        self.transport.push(order);
+    }
+
+    pub fn queue_production(&mut self, order: AdjustProduction) {
+        self.production.push(order);
+    }
+
+    pub fn queue_recruitment(&mut self, order: AdjustRecruitment) {
+        self.recruitment.push(order);
+    }
+
+    pub fn queue_training(&mut self, order: AdjustTraining) {
+        self.training.push(order);
+    }
+
+    pub fn clear(&mut self) {
+        self.production.clear();
+        self.recruitment.clear();
+        self.training.clear();
+        self.market.clear();
+        self.transport.clear();
+    }
+}
+
+/// Moves buffered AI orders into the shared queue so they can be executed alongside
+/// player-issued commands.
+pub fn flush_orders_to_queue(mut src: ResMut<OrdersOut>, mut dst: ResMut<OrdersQueue>) {
+    for order in src.production.drain(..) {
+        dst.queue_production(order);
+    }
+    for order in src.recruitment.drain(..) {
+        dst.queue_recruitment(order);
+    }
+    for order in src.training.drain(..) {
+        dst.queue_training(order);
+    }
+    for order in src.market.drain(..) {
+        dst.queue_market(order);
+    }
+    for order in src.transport.drain(..) {
+        dst.queue_transport(order);
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::orders::*;
-    use bevy::prelude::World;
+    use bevy::ecs::system::RunSystemOnce;
+    use bevy::prelude::{ResMut, World};
     use moonshine_kind::Instance;
 
+    use crate::economy::transport::{ImprovementKind, PlaceImprovement};
     use crate::economy::workforce::WorkerSkill;
     use crate::economy::{NationId, goods::Good};
 
@@ -95,12 +169,20 @@ mod tests {
             from_skill: WorkerSkill::Untrained,
             requested: 1,
         });
+        let improvement = PlaceImprovement {
+            a: bevy_ecs_tilemap::prelude::TilePos { x: 1, y: 2 },
+            b: bevy_ecs_tilemap::prelude::TilePos { x: 1, y: 3 },
+            kind: ImprovementKind::Rail,
+            engineer: None,
+        };
+
         queue.queue_market(AdjustMarketOrder {
             nation,
             good: Good::Cotton,
             kind: crate::messages::MarketInterest::Buy,
             requested: 5,
         });
+        queue.queue_transport(improvement);
 
         assert!(!queue.is_empty());
 
@@ -108,6 +190,7 @@ mod tests {
         assert_eq!(queue.take_recruitment().len(), 1);
         assert_eq!(queue.take_training().len(), 1);
         assert_eq!(queue.take_market().len(), 1);
+        assert_eq!(queue.take_transport().len(), 1);
         assert!(queue.is_empty());
     }
 
@@ -123,8 +206,47 @@ mod tests {
             nation,
             requested: 4,
         });
+        queue.queue_transport(PlaceImprovement {
+            a: bevy_ecs_tilemap::prelude::TilePos { x: 0, y: 0 },
+            b: bevy_ecs_tilemap::prelude::TilePos { x: 1, y: 0 },
+            kind: ImprovementKind::Road,
+            engineer: None,
+        });
 
         queue.clear();
         assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn flushes_buffered_orders() {
+        let mut world = World::new();
+        world.insert_resource(OrdersQueue::default());
+        world.insert_resource(OrdersOut::default());
+
+        let nation_entity = world.spawn(NationId(9)).id();
+        let nation = Instance::<NationId>::from_entity(world.entity(nation_entity)).unwrap();
+        {
+            let mut world_queue = world.resource_mut::<OrdersOut>();
+            world_queue.queue_market(AdjustMarketOrder {
+                nation,
+                good: Good::Coal,
+                kind: crate::messages::MarketInterest::Buy,
+                requested: 2,
+            });
+            world_queue.queue_transport(PlaceImprovement {
+                a: bevy_ecs_tilemap::prelude::TilePos { x: 0, y: 0 },
+                b: bevy_ecs_tilemap::prelude::TilePos { x: 0, y: 1 },
+                kind: ImprovementKind::Rail,
+                engineer: None,
+            });
+        }
+
+        let _ = world.run_system_once(|out: ResMut<OrdersOut>, queue: ResMut<OrdersQueue>| {
+            flush_orders_to_queue(out, queue);
+        });
+
+        let mut queue = world.resource_mut::<OrdersQueue>();
+        assert_eq!(queue.take_market().len(), 1);
+        assert_eq!(queue.take_transport().len(), 1);
     }
 }


### PR DESCRIPTION
## Summary
- integrate the macro-behavior PreUpdate pipeline, including the new analysis set, macro scorers/actions, and Thinker rebuilding that only runs during the enemy turn
- provide the BeliefState/MarketView/TransportAnalysis resources plus the plan ledger so analysis can produce macro candidates per AI nation
- introduce the OrdersOut buffer and transport order plumbing so AI actions enqueue work that the economy systems now execute alongside the player's queue

## Testing
- `cargo test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691918b3ba94832f96e7270fd2bcf3e2)