### PR TITLE
⚡ Avoid cloning CivilianTask in AI execution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,7 @@ debug = ["dep:bevy-inspector-egui"]
 
 [profile.release]
 debug = true
+
+[[bench]]
+name = "task_execution_benchmark"
+harness = false

--- a/benches/task_execution_benchmark.rs
+++ b/benches/task_execution_benchmark.rs
@@ -1,0 +1,51 @@
+use bevy::prelude::Entity;
+use bevy_ecs_tilemap::prelude::TilePos;
+use criterion::{Criterion, criterion_group, criterion_main, black_box};
+use rust_imperialism::ai::planner::CivilianTask;
+use rust_imperialism::ai::execute::sort_civilian_tasks_topologically;
+use std::collections::HashMap;
+
+fn create_test_data(count: u32) -> (HashMap<Entity, CivilianTask>, HashMap<TilePos, Entity>) {
+    let mut tasks = HashMap::new();
+    let mut positions = HashMap::new();
+
+    for i in 0..count {
+        let entity = Entity::from_bits(i as u64 + 1);
+        let pos = TilePos::new(i % 100, i / 100);
+
+        // Make a chain of dependencies: i moves to pos of i+1
+        // To do this, entity i is at pos i. Target is pos i+1.
+        // Entity i+1 is at pos i+1.
+
+        // This is a simple linear chain dependency:
+        // 0 -> 1 -> 2 -> ... -> N
+        // 0 is at (0,0), wants to move to (1,0) where 1 is.
+        // 1 is at (1,0), wants to move to (2,0) where 2 is.
+
+        let target_pos = if i < count - 1 {
+            TilePos::new((i + 1) % 100, (i + 1) / 100)
+        } else {
+             TilePos::new((i + 2) % 100, (i + 2) / 100)
+        };
+
+        tasks.insert(entity, CivilianTask::MoveTo { target: target_pos });
+        positions.insert(pos, entity);
+    }
+
+    (tasks, positions)
+}
+
+fn bench_topological_sort(c: &mut Criterion) {
+    // Large dataset to make cloning visible
+    let count = 2000;
+    let (tasks, positions) = create_test_data(count);
+
+    c.bench_function("sort_civilian_tasks_topologically", |b| {
+        b.iter(|| {
+            sort_civilian_tasks_topologically(black_box(&tasks), black_box(&positions))
+        })
+    });
+}
+
+criterion_group!(benches, bench_topological_sort);
+criterion_main!(benches);

--- a/benches/task_execution_benchmark.rs
+++ b/benches/task_execution_benchmark.rs
@@ -1,9 +1,10 @@
 use bevy::prelude::Entity;
 use bevy_ecs_tilemap::prelude::TilePos;
-use criterion::{Criterion, criterion_group, criterion_main, black_box};
-use rust_imperialism::ai::planner::CivilianTask;
+use criterion::{Criterion, criterion_group, criterion_main};
 use rust_imperialism::ai::execute::sort_civilian_tasks_topologically;
+use rust_imperialism::ai::planner::CivilianTask;
 use std::collections::HashMap;
+use std::hint::black_box;
 
 fn create_test_data(count: u32) -> (HashMap<Entity, CivilianTask>, HashMap<TilePos, Entity>) {
     let mut tasks = HashMap::new();
@@ -25,7 +26,7 @@ fn create_test_data(count: u32) -> (HashMap<Entity, CivilianTask>, HashMap<TileP
         let target_pos = if i < count - 1 {
             TilePos::new((i + 1) % 100, (i + 1) / 100)
         } else {
-             TilePos::new((i + 2) % 100, (i + 2) / 100)
+            TilePos::new((i + 2) % 100, (i + 2) / 100)
         };
 
         tasks.insert(entity, CivilianTask::MoveTo { target: target_pos });
@@ -41,9 +42,7 @@ fn bench_topological_sort(c: &mut Criterion) {
     let (tasks, positions) = create_test_data(count);
 
     c.bench_function("sort_civilian_tasks_topologically", |b| {
-        b.iter(|| {
-            sort_civilian_tasks_topologically(black_box(&tasks), black_box(&positions))
-        })
+        b.iter(|| sort_civilian_tasks_topologically(black_box(&tasks), black_box(&positions)))
     });
 }
 

--- a/src/ai/execute.rs
+++ b/src/ai/execute.rs
@@ -59,7 +59,7 @@ fn execute_plan(
 
     // Send civilian orders in sorted order
     for (civilian_entity, task) in execution_order {
-        if let Some(order) = task_to_order(&task) {
+        if let Some(order) = task_to_order(task) {
             commands.trigger(CivilianCommand {
                 civilian: civilian_entity,
                 order,
@@ -130,10 +130,10 @@ fn task_to_order(task: &CivilianTask) -> Option<CivilianOrderKind> {
 }
 
 /// Sort tasks to resolve dependencies (A wants to move to B's tile -> B must move first).
-fn sort_civilian_tasks_topologically(
-    tasks: &std::collections::HashMap<Entity, CivilianTask>,
+pub fn sort_civilian_tasks_topologically<'a>(
+    tasks: &'a std::collections::HashMap<Entity, CivilianTask>,
     current_positions: &std::collections::HashMap<bevy_ecs_tilemap::tiles::TilePos, Entity>,
-) -> Vec<(Entity, CivilianTask)> {
+) -> Vec<(Entity, &'a CivilianTask)> {
     use std::collections::{HashMap, HashSet};
 
     let mut graph: HashMap<Entity, HashSet<Entity>> = HashMap::new();
@@ -205,7 +205,7 @@ fn sort_civilian_tasks_topologically(
     // Map back to tasks
     sorted
         .into_iter()
-        .filter_map(|e| tasks.get(&e).map(|t| (e, t.clone())))
+        .filter_map(|e| tasks.get(&e).map(|t| (e, t)))
         .collect()
 }
 


### PR DESCRIPTION
This PR optimizes `sort_civilian_tasks_topologically` in `src/ai/execute.rs` by avoiding the cloning of `CivilianTask` objects. Instead, it returns references to the tasks stored in the original map. This reduces memory allocation and copying overhead during the AI execution phase.

Key changes:
- `sort_civilian_tasks_topologically` now returns `Vec<(Entity, &CivilianTask)>`.
- Updated `execute_plan` to handle the reference.
- Added `benches/task_execution_benchmark.rs` using `criterion`.


---
*PR created automatically by Jules for task [16109027243293271848](https://jules.google.com/task/16109027243293271848) started by @agluszak*